### PR TITLE
Avoid Registering Bees if Forestry Bee module is disabled. Prevents Crash

### DIFF
--- a/src/main/java/gregicadditions/GregicAdditions.java
+++ b/src/main/java/gregicadditions/GregicAdditions.java
@@ -2,6 +2,8 @@ package gregicadditions;
 
 import java.util.function.Function;
 
+import forestry.api.core.ForestryAPI;
+import net.minecraft.util.ResourceLocation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -61,7 +63,7 @@ public class GregicAdditions {
 
 	@EventHandler
 	public void init(FMLInitializationEvent event) {
-		if (GAConfig.GTBees.EnableGTCEBees && Loader.isModLoaded("forestry")) GTBees.initBees();
+		if (GAConfig.GTBees.EnableGTCEBees && Loader.isModLoaded("forestry") && ForestryAPI.enabledModules.contains(new ResourceLocation("forestry", "apiculture"))) GTBees.initBees();
 	}
 
 	@EventHandler

--- a/src/main/java/gregicadditions/bees/CommonProxy.java
+++ b/src/main/java/gregicadditions/bees/CommonProxy.java
@@ -2,6 +2,7 @@ package gregicadditions.bees;
 
 import java.util.Collections;
 
+import forestry.api.core.ForestryAPI;
 import forestry.api.recipes.ICentrifugeRecipe;
 import forestry.api.recipes.ISqueezerRecipe;
 import forestry.api.recipes.RecipeManagers;
@@ -14,6 +15,7 @@ import gregtech.api.recipes.builders.SimpleRecipeBuilder;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod;
@@ -58,14 +60,14 @@ public class CommonProxy {
 
 	@SubscribeEvent
 	public static void registerItems(RegistryEvent.Register<Item> event) {
-		if (!GAConfig.GTBees.EnableGTCEBees || !Loader.isModLoaded("forestry")) return;
+		if (!GAConfig.GTBees.EnableGTCEBees || !Loader.isModLoaded("forestry") || !ForestryAPI.enabledModules.contains(new ResourceLocation("forestry","apiculture"))) return;
 		IForgeRegistry<Item> registry = event.getRegistry();
 		registry.register(GTCombs.combItem);
 	}
 
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public static void registerRecipes(RegistryEvent.Register<IRecipe> event) {
-		if (!GAConfig.GTBees.EnableGTCEBees || !Loader.isModLoaded("forestry")) return;
+		if (!GAConfig.GTBees.EnableGTCEBees || !Loader.isModLoaded("forestry") || !ForestryAPI.enabledModules.contains(new ResourceLocation("forestry","apiculture"))) return;
 		ForestryMachineRecipes.init();
 	}
 }


### PR DESCRIPTION
This prevents the crash mentioned in #54 by checking to see if Apiculture module from Forestry is enabled before registering the bees and the combs.