### PR TITLE
Removed Bone Meal recipes as GTCE already adds them

### DIFF
--- a/src/main/java/gregicadditions/recipes/GARecipeAddition.java
+++ b/src/main/java/gregicadditions/recipes/GARecipeAddition.java
@@ -89,9 +89,7 @@ public class GARecipeAddition {
 		//GT5U Misc Recipes
 		ModHandler.addSmeltingRecipe(new ItemStack(Items.SLIME_BALL), MetaItems.RUBBER_DROP.getStackForm());
 		ModHandler.removeRecipeByName(new ResourceLocation("minecraft:bone_meal_from_bone"));
-		ModHandler.addShapelessRecipe("harder_bone_meal", new ItemStack(Items.DYE, 3, 15), new ItemStack(Items.BONE), ToolDictNames.craftingToolMortar);
-		RecipeMaps.FORGE_HAMMER_RECIPES.recipeBuilder().inputs(new ItemStack(Items.BONE)).outputs(new ItemStack(Items.DYE, 3, 15)).duration(16).EUt(10).buildAndRegister();
-		RecipeMaps.MACERATOR_RECIPES.recipeBuilder().inputs(new ItemStack(Items.BONE)).outputs(new ItemStack(Items.DYE, 3, 15)).duration(300).EUt(2).buildAndRegister();
+		RecipeMaps.FORGE_HAMMER_RECIPES.recipeBuilder().inputs(new ItemStack(Items.BONE)).outputs(new ItemStack(Items.DYE, 4, 15)).duration(16).EUt(10).buildAndRegister();
 
 		//GT6 Bending
 		if (GAConfig.GT6.BendingCurvedPlates && GAConfig.GT6.BendingCylinders) {


### PR DESCRIPTION
**Problem:**
There is duplicity in Bone to Bone Meal recipes. Because GTCE adds them now too. 

**How solved:**
Removed SoG duplicit recipes.
Updated Bone to Bone Meal recipe for Forge Hammer to be aligned with new output amounts.

**Outcome:**
Bone to Bone Meal recipe for Mortar and Pulverizer removes to favor GTCE recipes.
Bone to Bone Meal recipe for Forge Hammer outputs 4 instead of 3.