### PR TITLE
Fix Processing Array not running Electric Furnace Recipes

### DIFF
--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -107,7 +107,7 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 				return RecipeMaps.CENTRIFUGE_RECIPES;
 			case "electrolyzer":
 				return RecipeMaps.ELECTROLYZER_RECIPES;
-			case "furnace":
+			case "electric_furnace":
 				return RecipeMaps.FURNACE_RECIPES;
 			case "bender":
 				return RecipeMaps.BENDER_RECIPES;


### PR DESCRIPTION
Closes #72 

Changes the switch case to match the unlocalized name of the electric furnace.