### PR TITLE
Fix Crash when invalid machines were given to Processing Array

### DIFF
--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -368,6 +368,11 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 					String trimmedName = "";
 					String voltage = unlocalizedName.substring(unlocalizedName.lastIndexOf(".") + 1);
 					trimmedName = unlocalizedName.substring(0, unlocalizedName.lastIndexOf("."));
+
+					//Checks if the tile entity is actually a machine
+					if(!GAEnums.voltageMap.containsValue(voltage)) {
+						continue;
+					}
 					this.machineName = trimmedName.substring(trimmedName.lastIndexOf(".") + 1);
 					this.machineTierVoltage = GAEnums.voltageMap.get(voltage);
 					this.machineItemStack = wholeItemStack;


### PR DESCRIPTION
Closes #71 

Validates that the machines given to the input of the Processing Array can actually handle energy, instead of just being named `gregtech.machine.X` like Drums or the blast furnace controller. The fact that the machine can handle energy prevents the NPE when attempting to get the machine voltage by the voltage substring.