### PR TITLE
Refactor fusion reactor, use "heat" mechanic for EU-to-start costs

### DIFF
--- a/src/main/java/gregicadditions/machines/TileEntityFusionReactor.java
+++ b/src/main/java/gregicadditions/machines/TileEntityFusionReactor.java
@@ -158,7 +158,7 @@ public class TileEntityFusionReactor extends RecipeMapMultiblockController {
 		if (!getWorld().isRemote) {
 			if (this.inputEnergyContainers.getEnergyStored() > 0) {
 				long energyAdded = this.energyContainer.addEnergy(this.inputEnergyContainers.getEnergyStored());
-				if (energyAdded > 0) this.inputEnergyContainers.addEnergy(-energyAdded);
+				if (energyAdded > 0) this.inputEnergyContainers.removeEnergy(energyAdded);
 			}
 			super.updateFormedValid();
 		}
@@ -204,6 +204,7 @@ public class TileEntityFusionReactor extends RecipeMapMultiblockController {
 	private class FusionRecipeLogic extends MultiblockRecipeLogic {
 		public FusionRecipeLogic(TileEntityFusionReactor tileEntity) {
 			super(tileEntity);
+			this.allowOverclocking = false;
 		}
 
 		@Override
@@ -232,11 +233,6 @@ public class TileEntityFusionReactor extends RecipeMapMultiblockController {
 			energyContainer.removeEnergy(heatDiff);
 			heat += heatDiff;
 			return true;
-		}
-
-		@Override
-		protected int getOverclockingTier(long voltage) {
-			return 0;
 		}
 
 		@Override

--- a/src/main/java/gregicadditions/machines/TileEntityFusionReactor.java
+++ b/src/main/java/gregicadditions/machines/TileEntityFusionReactor.java
@@ -12,7 +12,7 @@ import codechicken.lib.vec.Matrix4;
 import gregicadditions.client.ClientHandler;
 import gregtech.api.GTValues;
 import gregtech.api.capability.IEnergyContainer;
-import gregtech.api.capability.impl.AbstractRecipeLogic;
+import gregtech.api.capability.IMultipleTankHandler;
 import gregtech.api.capability.impl.EnergyContainerHandler;
 import gregtech.api.capability.impl.EnergyContainerList;
 import gregtech.api.capability.impl.FluidTankList;
@@ -35,26 +35,23 @@ import gregtech.common.blocks.BlockWireCoil;
 import gregtech.common.blocks.MetaBlocks;
 import gregtech.common.metatileentities.MetaTileEntities;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.Style;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
-import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import net.minecraftforge.items.IItemHandlerModifiable;
 
 public class TileEntityFusionReactor extends RecipeMapMultiblockController {
 	private final int tier;
 	private EnergyContainerList inputEnergyContainers;
+	private int heat = 0; // defined in TileEntityFusionReactor but serialized in FusionRecipeLogic
 
 	public TileEntityFusionReactor(ResourceLocation metaTileEntityId, int tier) {
 		super(metaTileEntityId, RecipeMaps.FUSION_RECIPES);
-		this.recipeMapWorkable = new MultiblockRecipeLogic(this) {
-			@Override
-			protected int getOverclockingTier(long voltage) {
-				return 0;
-			}
-		};
+		this.recipeMapWorkable = new FusionRecipeLogic(this);
 		this.tier = tier;
 		this.reinitializeStructurePattern();
 		this.energyContainer = new EnergyContainerHandler(this, Integer.MAX_VALUE, 0, 0, 0, 0) {
@@ -73,12 +70,35 @@ public class TileEntityFusionReactor extends RecipeMapMultiblockController {
 	@Override
 	protected BlockPattern createStructurePattern() {
 		FactoryBlockPattern.start();
-		return FactoryBlockPattern.start(LEFT, DOWN, BACK).aisle("###############", "######OCO######", "###############").aisle("######ICI######", "####CCcccCC####", "######ICI######").aisle("####CC###CC####", "###EccOCOccE###", "####CC###CC####").aisle("###C#######C###", "##EcEC###CEcE##", "###C#######C###").aisle("##C#########C##", "#CcE#######EcC#", "##C#########C##").aisle("##C#########C##", "#CcC#######CcC#", "##C#########C##").aisle("#I###########I#", "OcO#########OcO", "#I###########I#").aisle("#C###########C#", "CcC#########CcC", "#C###########C#").aisle("#I###########I#", "OcO#########OcO", "#I###########I#").aisle("##C#########C##", "#CcC#######CcC#", "##C#########C##").aisle("##C#########C##", "#CcE#######EcC#", "##C#########C##").aisle("###C#######C###", "##EcEC###CEcE##", "###C#######C###").aisle("####CC###CC####", "###EccOCOccE###", "####CC###CC####").aisle("######ICI######", "####CCcccCC####", "######ICI######").aisle("###############", "######OSO######", "###############").where('S', selfPredicate()).where('C', statePredicate(getCasingState())).where('c', statePredicate(getCoilState())).where('O', statePredicate(getCasingState()).or(abilityPartPredicate(MultiblockAbility.EXPORT_FLUIDS))).where('E', statePredicate(getCasingState()).or(tilePredicate((state, tile) -> {
-			for (int i = tier; i < GTValues.V.length; i++) {
-				if (tile.metaTileEntityId.equals(MetaTileEntities.ENERGY_INPUT_HATCH[i].metaTileEntityId)) return true;
-			}
-			return false;
-		}))).where('I', statePredicate(getCasingState()).or(abilityPartPredicate(MultiblockAbility.IMPORT_FLUIDS))).where('#', (tile) -> true).build();
+		return FactoryBlockPattern.start(LEFT, DOWN, BACK)
+				.aisle("###############", "######OCO######", "###############")
+				.aisle("######ICI######", "####CCcccCC####", "######ICI######")
+				.aisle("####CC###CC####", "###EccOCOccE###", "####CC###CC####")
+				.aisle("###C#######C###", "##EcEC###CEcE##", "###C#######C###")
+				.aisle("##C#########C##", "#CcE#######EcC#", "##C#########C##")
+				.aisle("##C#########C##", "#CcC#######CcC#", "##C#########C##")
+				.aisle("#I###########I#", "OcO#########OcO", "#I###########I#")
+				.aisle("#C###########C#", "CcC#########CcC", "#C###########C#")
+				.aisle("#I###########I#", "OcO#########OcO", "#I###########I#")
+				.aisle("##C#########C##", "#CcC#######CcC#", "##C#########C##")
+				.aisle("##C#########C##", "#CcE#######EcC#", "##C#########C##")
+				.aisle("###C#######C###", "##EcEC###CEcE##", "###C#######C###")
+				.aisle("####CC###CC####", "###EccOCOccE###", "####CC###CC####")
+				.aisle("######ICI######", "####CCcccCC####", "######ICI######")
+				.aisle("###############", "######OSO######", "###############")
+				.where('S', selfPredicate())
+				.where('C', statePredicate(getCasingState()))
+				.where('c', statePredicate(getCoilState()))
+				.where('O', statePredicate(getCasingState()).or(abilityPartPredicate(MultiblockAbility.EXPORT_FLUIDS)))
+				.where('E', statePredicate(getCasingState()).or(tilePredicate((state, tile) -> {
+					for (int i = tier; i < GTValues.V.length; i++) {
+						if (tile.metaTileEntityId.equals(MetaTileEntities.ENERGY_INPUT_HATCH[i].metaTileEntityId)) return true;
+					}
+					return false;
+				})))
+				.where('I', statePredicate(getCasingState()).or(abilityPartPredicate(MultiblockAbility.IMPORT_FLUIDS)))
+				.where('#', (tile) -> true)
+				.build();
 	}
 
 	@Override
@@ -87,7 +107,6 @@ public class TileEntityFusionReactor extends RecipeMapMultiblockController {
 	}
 
 	private IBlockState getCasingState() {
-
 		switch (tier) {
 		case 6:
 			return MetaBlocks.MACHINE_CASING.getState(BlockMachineCasing.MachineCasingType.LuV);
@@ -100,7 +119,6 @@ public class TileEntityFusionReactor extends RecipeMapMultiblockController {
 	}
 
 	private IBlockState getCoilState() {
-
 		switch (tier) {
 		case 6:
 			return MetaBlocks.WIRE_COIL.getState(BlockWireCoil.CoilType.SUPERCONDUCTOR);
@@ -109,11 +127,6 @@ public class TileEntityFusionReactor extends RecipeMapMultiblockController {
 		default:
 			return MetaBlocks.WIRE_COIL.getState(BlockWireCoil.CoilType.FUSION_COIL);
 		}
-	}
-
-	private long getMaxEU() {
-		List<IEnergyContainer> eConts = ObfuscationReflectionHelper.getPrivateValue(EnergyContainerList.class, this.inputEnergyContainers, "energyContainerList");
-		return eConts.size() * 10000000L * (long) Math.pow(2, tier - 6);
 	}
 
 	@Override
@@ -129,8 +142,10 @@ public class TileEntityFusionReactor extends RecipeMapMultiblockController {
 		this.inputFluidInventory = new FluidTankList(true, getAbilities(MultiblockAbility.IMPORT_FLUIDS));
 		this.outputInventory = new ItemHandlerList(getAbilities(MultiblockAbility.EXPORT_ITEMS));
 		this.outputFluidInventory = new FluidTankList(true, getAbilities(MultiblockAbility.EXPORT_FLUIDS));
-		this.inputEnergyContainers = new EnergyContainerList(this.getAbilities(MultiblockAbility.INPUT_ENERGY));
-		this.energyContainer = new EnergyContainerHandler(this, getMaxEU(), GTValues.V[tier], 0, 0, 0) {
+		List<IEnergyContainer> energyInputs = getAbilities(MultiblockAbility.INPUT_ENERGY);
+		this.inputEnergyContainers = new EnergyContainerList(energyInputs);
+		long euCapacity = energyInputs.size() * 10000000L * (long) Math.pow(2, tier - 6);
+		this.energyContainer = new EnergyContainerHandler(this, euCapacity, GTValues.V[tier], 0, 0, 0) {
 			@Override
 			public String getName() {
 				return "EnergyContainerInternal";
@@ -145,85 +160,96 @@ public class TileEntityFusionReactor extends RecipeMapMultiblockController {
 				long energyAdded = this.energyContainer.addEnergy(this.inputEnergyContainers.getEnergyStored());
 				if (energyAdded > 0) this.inputEnergyContainers.addEnergy(-energyAdded);
 			}
-
-			if (this.recipeMapWorkable.isWorkingEnabled()) {
-				if (this.recipeMapWorkable.isHasNotEnoughEnergy()) {
-					ObfuscationReflectionHelper.setPrivateValue(AbstractRecipeLogic.class, recipeMapWorkable, 0, "progressTime");
-					recipeMapWorkable.setMaxProgress(0);
-					ObfuscationReflectionHelper.setPrivateValue(AbstractRecipeLogic.class, recipeMapWorkable, 0, "recipeEUt");
-					ObfuscationReflectionHelper.setPrivateValue(AbstractRecipeLogic.class, recipeMapWorkable, null, "fluidOutputs");
-					ObfuscationReflectionHelper.setPrivateValue(AbstractRecipeLogic.class, recipeMapWorkable, null, "itemOutputs");
-					ObfuscationReflectionHelper.setPrivateValue(AbstractRecipeLogic.class, recipeMapWorkable, false, "hasNotEnoughEnergy");
-					ObfuscationReflectionHelper.setPrivateValue(AbstractRecipeLogic.class, recipeMapWorkable, true, "wasActiveAndNeedsUpdate");
-					return;
-				}
-				Recipe previousRecipe = ObfuscationReflectionHelper.getPrivateValue(AbstractRecipeLogic.class, recipeMapWorkable, "previousRecipe");
-				this.recipeMapWorkable.updateWorkable();
-				Recipe recipe = ObfuscationReflectionHelper.getPrivateValue(AbstractRecipeLogic.class, recipeMapWorkable, "previousRecipe");
-				if (previousRecipe != recipe) {
-					if (recipe != null) {
-						long euToStart = ((Integer) recipe.getProperty("eu_to_start")).intValue();
-						if (this.energyContainer.getEnergyStored() < euToStart) {
-							ObfuscationReflectionHelper.setPrivateValue(AbstractRecipeLogic.class, recipeMapWorkable, 0, "progressTime");
-							recipeMapWorkable.setMaxProgress(0);
-							ObfuscationReflectionHelper.setPrivateValue(AbstractRecipeLogic.class, recipeMapWorkable, 0, "recipeEUt");
-							ObfuscationReflectionHelper.setPrivateValue(AbstractRecipeLogic.class, recipeMapWorkable, null, "fluidOutputs");
-							ObfuscationReflectionHelper.setPrivateValue(AbstractRecipeLogic.class, recipeMapWorkable, null, "itemOutputs");
-							ObfuscationReflectionHelper.setPrivateValue(AbstractRecipeLogic.class, recipeMapWorkable, false, "hasNotEnoughEnergy");
-							ObfuscationReflectionHelper.setPrivateValue(AbstractRecipeLogic.class, recipeMapWorkable, false, "hasNotEnoughEnergy");
-							ObfuscationReflectionHelper.setPrivateValue(AbstractRecipeLogic.class, recipeMapWorkable, true, "wasActiveAndNeedsUpdate");
-						} else {
-							this.energyContainer.addEnergy(-euToStart);
-						}
-					} else {
-						ObfuscationReflectionHelper.setPrivateValue(AbstractRecipeLogic.class, recipeMapWorkable, 0, "progressTime");
-						recipeMapWorkable.setMaxProgress(0);
-						ObfuscationReflectionHelper.setPrivateValue(AbstractRecipeLogic.class, recipeMapWorkable, 0, "recipeEUt");
-						ObfuscationReflectionHelper.setPrivateValue(AbstractRecipeLogic.class, recipeMapWorkable, null, "fluidOutputs");
-						ObfuscationReflectionHelper.setPrivateValue(AbstractRecipeLogic.class, recipeMapWorkable, null, "itemOutputs");
-						ObfuscationReflectionHelper.setPrivateValue(AbstractRecipeLogic.class, recipeMapWorkable, false, "hasNotEnoughEnergy");
-						ObfuscationReflectionHelper.setPrivateValue(AbstractRecipeLogic.class, recipeMapWorkable, false, "hasNotEnoughEnergy");
-						ObfuscationReflectionHelper.setPrivateValue(AbstractRecipeLogic.class, recipeMapWorkable, true, "wasActiveAndNeedsUpdate");
-					}
-				}
-			}
-
+			super.updateFormedValid();
 		}
 	}
 
 	@Override
 	protected void addDisplayText(List<ITextComponent> textList) {
 		if (!this.isStructureFormed()) {
-			textList.add(new TextComponentTranslation("gregtech.multiblock.invalid_structure", new Object[0]).setStyle(new Style().setColor(TextFormatting.RED)));
+			textList.add(new TextComponentTranslation("gregtech.multiblock.invalid_structure").setStyle(new Style().setColor(TextFormatting.RED)));
 		}
 		if (this.isStructureFormed()) {
 			if (!this.recipeMapWorkable.isWorkingEnabled()) {
-				textList.add(new TextComponentTranslation("gregtech.multiblock.work_paused", new Object[0]));
+				textList.add(new TextComponentTranslation("gregtech.multiblock.work_paused"));
 			} else if (this.recipeMapWorkable.isActive()) {
-				textList.add(new TextComponentTranslation("gregtech.multiblock.running", new Object[0]));
+				textList.add(new TextComponentTranslation("gregtech.multiblock.running"));
 				int currentProgress;
 				if (energyContainer.getEnergyCapacity() > 0) {
 					currentProgress = (int) (this.recipeMapWorkable.getProgressPercent() * 100.0D);
-					textList.add(new TextComponentTranslation("gregtech.multiblock.progress", new Object[] { currentProgress }));
+					textList.add(new TextComponentTranslation("gregtech.multiblock.progress", currentProgress));
 				} else {
 					currentProgress = -this.recipeMapWorkable.getRecipeEUt();
-					textList.add(new TextComponentTranslation("gregtech.multiblock.generation_eu", new Object[] { currentProgress }));
+					textList.add(new TextComponentTranslation("gregtech.multiblock.generation_eu", currentProgress));
 				}
 			} else {
-				textList.add(new TextComponentTranslation("gregtech.multiblock.idling", new Object[0]));
+				textList.add(new TextComponentTranslation("gregtech.multiblock.idling"));
 			}
 
 			if (this.recipeMapWorkable.isHasNotEnoughEnergy()) {
-				textList.add(new TextComponentTranslation("gregtech.multiblock.not_enough_energy", new Object[0]).setStyle(new Style().setColor(TextFormatting.RED)));
+				textList.add(new TextComponentTranslation("gregtech.multiblock.not_enough_energy").setStyle(new Style().setColor(TextFormatting.RED)));
 			}
 		}
 
 		textList.add(new TextComponentString("EU: " + this.energyContainer.getEnergyStored() + " / " + this.energyContainer.getEnergyCapacity()));
+		textList.add(new TextComponentTranslation("gregtech.multiblock.fusion_reactor.heat", heat));
 	}
 
 	@Override
 	public void renderMetaTileEntity(CCRenderState renderState, Matrix4 translation, IVertexOperation[] pipeline) {
 		this.getBaseTexture(null).render(renderState, translation, pipeline);
 		ClientHandler.FUSION_REACTOR_OVERLAY.render(renderState, translation, pipeline, this.getFrontFacing(), this.recipeMapWorkable.isActive());
+	}
+
+	private class FusionRecipeLogic extends MultiblockRecipeLogic {
+		public FusionRecipeLogic(TileEntityFusionReactor tileEntity) {
+			super(tileEntity);
+		}
+
+		@Override
+		public void updateWorkable() {
+			super.updateWorkable();
+			if (!isActive && heat > 0) {
+				heat = heat <= 10000 ? 0 : (heat - 10000);
+			}
+		}
+
+		@Override
+		protected Recipe findRecipe(long maxVoltage, IItemHandlerModifiable inputs, IMultipleTankHandler fluidInputs) {
+			Recipe recipe = super.findRecipe(maxVoltage, inputs, fluidInputs);
+			return (recipe != null && recipe.getIntegerProperty("eu_to_start") <= energyContainer.getEnergyCapacity()) ? recipe : null;
+		}
+
+		@Override
+		protected boolean setupAndConsumeRecipeInputs(Recipe recipe) {
+			int heatDiff = recipe.getIntegerProperty("eu_to_start") - heat;
+			if (heatDiff <= 0) {
+				return super.setupAndConsumeRecipeInputs(recipe);
+			}
+			if (energyContainer.getEnergyStored() < heatDiff || !super.setupAndConsumeRecipeInputs(recipe)) {
+				return false;
+			}
+			energyContainer.removeEnergy(heatDiff);
+			heat += heatDiff;
+			return true;
+		}
+
+		@Override
+		protected int getOverclockingTier(long voltage) {
+			return 0;
+		}
+
+		@Override
+		public NBTTagCompound serializeNBT() {
+			NBTTagCompound tag = super.serializeNBT();
+			tag.setInteger("Heat", heat);
+			return tag;
+		}
+
+		@Override
+		public void deserializeNBT(NBTTagCompound compound) {
+			super.deserializeNBT(compound);
+			heat = compound.getInteger("Heat");
+		}
 	}
 }

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -649,11 +649,12 @@ item.meat.dust=Mince Meat
 
 gregtech.multiblock.coke_oven.description=The Coke Oven is a 3x3 multiblock structure used for turning Coal into Coal Coke, Lignite into Lignite Coke and Logs into Charcoal, with Creosote Oil as a byproduct.
 gregtech.multiblock.assembly_line.description=The Assembly Line is a large multiblock structure consisting of 5 to 16 "slices". In theory, it's large Assembling Machine, used for creating advanced crafting components.
-gregtech.multiblock.processing_array.description=The Processing Array combines up to 16 single block machines in a single multiblock, effectively easing automation. 
+gregtech.multiblock.processing_array.description=The Processing Array combines up to 16 single block machines in a single multiblock, effectively easing automation.
 gregtech.multiblock.distill_tower.description=The GA Distillation Tower is a multiblock structure consisting of 2-12 layers. It's used for distilling fluids, but unlike the Distillery, gives you multiple outputs per input, including item outputs. Every layer has a different output.
 gregtech.multiblock.fusion_reactor_mk1.description=The Fusion Reactor Mark 1 is a large multiblock structure used for fusing elements into heavier ones. The Mark 1 Fusion Reactor can use LuV, ZPM or UV Energy Hatches. For every Hatch it has its buffer increases by 100k.
 gregtech.multiblock.fusion_reactor_mk2.description=The Fusion Reactor Mark 2 is a large multiblock structure used for fusing elements into heavier ones. The Mark 2 Fusion Reactor can use ZPM or UV Energy Hatches. For every Hatch it has its buffer increases by 200k.
 gregtech.multiblock.fusion_reactor_mk3.description=The Fusion Reactor Mark 3 is a large multiblock structure used for fusing elements into heavier ones. The Mark 3 Fusion Reactor can only use UV Energy Hatches. For every Hatch it has its buffer increases by 400k.
+gregtech.multiblock.fusion_reactor.heat=Heat: %d
 
 item.material.oreprefix.plateCurved=Curved %s Plate
 item.material.oreprefix.ingotDouble=Double %s Ingot

--- a/src/main/resources/assets/gtadditions/lang/ru_ru.lang
+++ b/src/main/resources/assets/gtadditions/lang/ru_ru.lang
@@ -654,6 +654,7 @@ gregtech.multiblock.distill_tower.description=The GA Distillation Tower is a mul
 gregtech.multiblock.fusion_reactor_mk1.description=The Fusion Reactor Mark 1 is a large multiblock structure used for fusing elements into heavier ones. The Mark 1 Fusion Reactor can use LuV, ZPM or UV Energy Hatches. For every Hatch it has its buffer increases by 100k.
 gregtech.multiblock.fusion_reactor_mk2.description=The Fusion Reactor Mark 2 is a large multiblock structure used for fusing elements into heavier ones. The Mark 2 Fusion Reactor can use ZPM or UV Energy Hatches. For every Hatch it has its buffer increases by 200k.
 gregtech.multiblock.fusion_reactor_mk3.description=The Fusion Reactor Mark 3 is a large multiblock structure used for fusing elements into heavier ones. The Mark 3 Fusion Reactor can only use UV Energy Hatches. For every Hatch it has its buffer increases by 400k.
+gregtech.multiblock.fusion_reactor.heat=Теплота: %d
 
 item.material.oreprefix.plateCurved=Изогнутая %s пластина
 item.material.oreprefix.ingotDouble=%s (Двойной слиток)

--- a/src/main/resources/assets/gtadditions/lang/zh_cn.lang
+++ b/src/main/resources/assets/gtadditions/lang/zh_cn.lang
@@ -632,6 +632,7 @@ gregtech.multiblock.distill_tower.description=GA蒸馏塔是一台多方块机�
 gregtech.multiblock.fusion_reactor_mk1.description=核聚变反应堆 Mk I 是一台可以通过聚变生产重元素的大型多方块机器。它可以使用LuV，ZPM或者UV等级的能源仓。每一个能源仓可以增加100kEU的能量缓存。
 gregtech.multiblock.fusion_reactor_mk2.description=核聚变反应堆 Mk II 是一台可以通过聚变生产重元素的大型多方块机器。它可以使用ZPM或者UV等级的能源仓。每一个能源仓可以增加200kEU的能量缓存。
 gregtech.multiblock.fusion_reactor_mk3.description=核聚变反应堆 Mk III 是一台可以通过聚变生产重元素的大型多方块机器。它只能使用UV等级的能源仓。每一个能源仓可以增加400kEU的能量缓存。
+gregtech.multiblock.fusion_reactor.heat=热力: %d
 
 item.material.oreprefix.plateCurved=弯曲%s板
 item.material.oreprefix.ingotDouble=双重%s锭


### PR DESCRIPTION
This PR provides improvements to code structure and implementation in `TileEntitiyFusionReactor`, and also changes the behaviour of the reactor with regard to the EU-to-start cost.

Summary:
* Fixes #75
* Removes all the reflection hacks
* Introduces the "heat" mechanic

The "heat" is a value representing the "temperature", in some sense, of the reactor. It is assumed that the EU-to-start cost of a given fusion recipe is representative of the amount of heat required to jump-start the fusion; thus, if the current reactor heat value is higher than the EU-to-start cost of the recipe attempting to run, then the recipe will be able to run without incurring any additional energy expenditure. On the other hand, if the heat is lower than the EU-to-start cost of the recipe, then the difference between the current heat and the required heat is expended to increase the heat as necessary. If the reactor has no heat (e.g. has just been built), then the full EU-to-start cost will need to be satisfied to start the recipe. While the reactor is idle, the heat will slowly decay back to zero.

The result of this is that running the same recipe multiple times in sequence will only cause the EU-to-start cost to be incurred once, at the very beginning. Additionally, it means that switching one reactor between multiple different recipes in sequence will not incur enormous costs; rather than incurring the full EU-to-start cost of a new recipe every time a switch is made, only enough energy needed to start the most expensive recipe will be deducted, since the heat for that recipe will be sufficient to run any of the lower-cost recipes in the sequence. The slow decay of heat while idle also means players aren't punished as hard for reactor downtime as if the heat were instantly reset to zero.