### PR TITLE
Add a minimum number of required casing blocks to Processing Array.

### DIFF
--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -55,7 +55,15 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 	@Override
 	protected BlockPattern createStructurePattern() {
 
-		return FactoryBlockPattern.start().aisle("XXX", "XXX", "XXX").aisle("XXX", "X#X", "XXX").aisle("XXX", "XSX", "XXX").where('S', selfPredicate()).where('X', statePredicate(getCasingState()).or(abilityPartPredicate(ALLOWED_ABILITIES))).where('#', isAirPredicate()).build();
+		return FactoryBlockPattern.start()
+				.aisle("XXX", "XXX", "XXX")
+				.aisle("XXX", "X#X", "XXX")
+				.aisle("XXX", "XSX", "XXX")
+				.setAmountAtLeast('L', 12)
+				.where('L', statePredicate(getCasingState()))
+				.where('S', selfPredicate())
+				.where('X', statePredicate(getCasingState()).or(abilityPartPredicate(ALLOWED_ABILITIES)))
+				.where('#', isAirPredicate()).build();
 
 	}
 


### PR DESCRIPTION
Adds a minimum number of required casing blocks to the Processing Array Multiblock. Otherwise, the mutliblock could be made entirely of IO buses/hatches and the controller. Requiring 12 casing blocks minimum is generous, as it allows for 8 Energy inputs to overclock 2 tiers, 1 of each input/output bus/hatch and 2 additional slots. Or any combination of input/output limited to 14 total.