### PR TITLE
Extend possible Length of AL to match recipe Map

### DIFF
--- a/src/main/java/gregicadditions/machines/TileEntityAssemblyLine.java
+++ b/src/main/java/gregicadditions/machines/TileEntityAssemblyLine.java
@@ -36,11 +36,25 @@ public class TileEntityAssemblyLine extends RecipeMapMultiblockController {
 
 	@Override
 	protected BlockPattern createStructurePattern() {
-		return FactoryBlockPattern.start(LEFT, DOWN, BACK).aisle("#Y#", "GAG", "RTR", "COC").aisle("#Y#", "GAG", "RTR", "FIF").setRepeatable(3, 14).aisle("#Y#", "GSG", "RTR", "FIF").where('S', selfPredicate()).where('C', statePredicate(getCasingState())).where('F', statePredicate(getCasingState()).or(abilityPartPredicate(MultiblockAbility.IMPORT_FLUIDS))).where('O', statePredicate(getCasingState()).or(abilityPartPredicate(MultiblockAbility.EXPORT_ITEMS))).where('Y', statePredicate(getCasingState()).or(abilityPartPredicate(MultiblockAbility.INPUT_ENERGY))).where('I', tilePredicate((state, tile) -> {
-			return tile.metaTileEntityId.equals(MetaTileEntities.ITEM_IMPORT_BUS[0].metaTileEntityId);
-		})).where('G', statePredicate(MetaBlocks.MUTLIBLOCK_CASING.getState(BlockMultiblockCasing.MultiblockCasingType.GRATE_CASING))).where('A', statePredicate(MetaBlocks.MUTLIBLOCK_CASING.getState(BlockMultiblockCasing.MultiblockCasingType.ASSEMBLER_CASING))).where('R', statePredicate(GAMetaBlocks.TRANSPARENT_CASING.getState(GATransparentCasing.CasingType.REINFORCED_GLASS))).where('T', statePredicate(GAMetaBlocks.MUTLIBLOCK_CASING.getState(GAMultiblockCasing.CasingType.TUNGSTENSTEEL_GEARBOX_CASING))).where('#', (tile) -> {
-			return true;
-		}).build();
+		return FactoryBlockPattern.start(LEFT, DOWN, BACK)
+					.aisle("#Y#", "GAG", "RTR", "COC")
+					.aisle("#Y#", "GAG", "RTR", "FIF").setRepeatable(3, 15)
+					.aisle("#Y#", "GSG", "RTR", "FIF")
+					.where('S', selfPredicate())
+					.where('C', statePredicate(getCasingState()))
+					.where('F', statePredicate(getCasingState()).or(abilityPartPredicate(MultiblockAbility.IMPORT_FLUIDS)))
+					.where('O', statePredicate(getCasingState()).or(abilityPartPredicate(MultiblockAbility.EXPORT_ITEMS)))
+					.where('Y', statePredicate(getCasingState()).or(abilityPartPredicate(MultiblockAbility.INPUT_ENERGY)))
+					.where('I', tilePredicate((state, tile) -> {
+						return tile.metaTileEntityId.equals(MetaTileEntities.ITEM_IMPORT_BUS[0].metaTileEntityId); }))
+					.where('G', statePredicate(MetaBlocks.MUTLIBLOCK_CASING.getState(BlockMultiblockCasing.MultiblockCasingType.GRATE_CASING)))
+					.where('A', statePredicate(MetaBlocks.MUTLIBLOCK_CASING.getState(BlockMultiblockCasing.MultiblockCasingType.ASSEMBLER_CASING)))
+					.where('R', statePredicate(GAMetaBlocks.TRANSPARENT_CASING.getState(GATransparentCasing.CasingType.REINFORCED_GLASS)))
+					.where('T', statePredicate(GAMetaBlocks.MUTLIBLOCK_CASING.getState(GAMultiblockCasing.CasingType.TUNGSTENSTEEL_GEARBOX_CASING)))
+					.where('#', (tile) -> {
+						return true; })
+					.build();
+
 		/*return FactoryBlockPattern.start(RIGHT, UP, FRONT)
 		        .aisle("YXX", "XXX")
 		        .aisle("YXX", "XXX")


### PR DESCRIPTION
Closes #85 

Extends the possible length of the Assembly Line by 1 block, to match the number of item inputs available in the pattern to the number of item inputs defined in its recipeMap. Also does a general cleanup of the Assembly Line structure pattern to make it more readable.