### PR TITLE
Fix some errors that were noticed after the Recipe Cleanup PR.

### DIFF
--- a/src/main/java/gregicadditions/recipes/GAMachineRecipeRemoval.java
+++ b/src/main/java/gregicadditions/recipes/GAMachineRecipeRemoval.java
@@ -86,13 +86,6 @@ public class GAMachineRecipeRemoval {
 		//Circuit Rabbit Hole-Related Recipe Removal
 		removeRecipesByInputs(RecipeMaps.CHEMICAL_RECIPES, new ItemStack[] { OreDictUnifier.get(OrePrefix.dust, Materials.Silicon) }, new FluidStack[] { Materials.Epichlorhydrin.getFluid(144) });
 
-		//Remove Hydrogen Sulfide Recipes
-		removeRecipesByInputs(RecipeMaps.CHEMICAL_RECIPES, Materials.NaturalGas.getFluid(16000), Materials.Hydrogen.getFluid(2000));
-		removeRecipesByInputs(RecipeMaps.CHEMICAL_RECIPES, Materials.SulfuricGas.getFluid(16000), Materials.Hydrogen.getFluid(2000));
-		removeRecipesByInputs(RecipeMaps.CHEMICAL_RECIPES, Materials.SulfuricLightFuel.getFluid(12000), Materials.Hydrogen.getFluid(2000));
-		removeRecipesByInputs(RecipeMaps.CHEMICAL_RECIPES, Materials.SulfuricHeavyFuel.getFluid(8000), Materials.Hydrogen.getFluid(2000));
-		removeRecipesByInputs(RecipeMaps.CHEMICAL_RECIPES, Materials.SulfuricNaphtha.getFluid(12000), Materials.Hydrogen.getFluid(2000));
-
 		//Remove GT5 Ash Centrifuging
 		removeRecipesByInputs(RecipeMaps.CENTRIFUGE_RECIPES, OreDictUnifier.get(OrePrefix.dust, Materials.DarkAsh, 2));
 		removeRecipesByInputs(RecipeMaps.CENTRIFUGE_RECIPES, OreDictUnifier.get(OrePrefix.dust, Materials.Ash));
@@ -126,6 +119,8 @@ public class GAMachineRecipeRemoval {
 		removeRecipesByInputs(RecipeMaps.CUTTER_RECIPES, new ItemStack[] { new ItemStack(Blocks.QUARTZ_BLOCK) }, new FluidStack[] { Materials.Lubricant.getFluid(18) });
 		removeRecipesByInputs(RecipeMaps.CUTTER_RECIPES, new ItemStack[] { OreDictUnifier.get(OrePrefix.block, Materials.CertusQuartz) }, new FluidStack[] { Materials.Lubricant.getFluid(18) });
 
+		//Remove expensive Iridium recipe
+		removeRecipesByInputs(RecipeMaps.FUSION_RECIPES, Materials.Lithium.getFluid(16), Materials.Tungsten.getFluid(16));
 	}
 
 	private static <R extends RecipeBuilder<R>> void removeRecipesByInputs(RecipeMap<R> map, ItemStack... itemInputs) {


### PR DESCRIPTION
This PR fixes some issues that were noticed after the recipe cleanup PR was merged.

First: The Iridium fusion recipe removal was re-added, as I apparently overlooked this recipe when I was testing the PR, and it actually is a recipe that exists, therefore the removal was valid.

Second: Removes the set of recipes removals labelled as "Hydrogen Sulfide" recipes. These recipe removals originally did not work because of incorrect fluid amounts, until I adjusted the removals to work in my cleanup PR. However, I overlooked that the main point of the recipes was not the Hydrogen Sulfide, as mentioned by the comment, but instead serving as desulfurization recipes serving to make regular versions of the sulfurized fuels. With these recipe removals working, there are several fuels that are no longer obtainable, because the main methods of obtaining them was through the desulfurization recipes. In addition, Hydrogen Sulfide has another recipe not removed in this block, so these removal statements were essentially in error in the first place.