### PR TITLE
Update Gregtech CE version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     deobfCompile "mezz.jei:jei_1.12.2:+"
 	deobfCompile "mcp.mobius.waila:Hwyla:1.8+"
     deobfCompile "net.sengir.forestry:forestry_1.12.2:+"
-	deobfCompile "gregtechce:gregtech:1.12.2:1.10.1.557"
+	deobfCompile "gregtechce:gregtech:1.12.2:1.10.8.599"
 	deobfCompile "codechicken:ChickenASM:1.12-+"
     deobfCompile "codechicken-lib-1-8:CodeChickenLib-1.12.2:3.2.3.357:universal"
     deobfCompile "forge-multipart-cbe:ForgeMultipart-1.12.2:2.6.2.83:universal"


### PR DESCRIPTION
Updates the dependency version of Gregtech CE.

This is done in order to fix a crash with the Processing Array that would occur some times with GTCE 1.10.8.599 and SoG 2.15 due to the changes in recipe output allocations done in GTCE 1.10.8.599 done to prevent multiblocks from voiding some of their outputs. 

The crash occurs because of attempting to add an abnormally large itemstack to the output of a multiblock, which was one case now caught in the recent gtce update to prevent parts of the recipe output from being voided if there was not enough room in output buses of the multiblock. In a reproduction case of the crash, where the recipe in the Processing Array was for Naquadah Boules -> wafers, with 16 cutting machines, and the only output on the multiblock being an LV output bus, a single stack of 1024 wafers would attempt to be added to the mutliblock, even though the wafers only stack to 64. Which would have before been partially voided due to not all fitting in the output bus, but in the newer GTCE version the recipe is simply cancelled, because there is not enough room in the combined outputs of the mutliblock. This was solved by instead creating (in the case of the example) 16 stacks, each with 64 wafers and then attempting to add them to the output, and cancelling the recipe if not all of them would fit.