### PR TITLE
Cleanup Generator Fuel additions and remove more obsolete additions

### DIFF
--- a/src/main/java/gregicadditions/jei/GAMultiblockInfoCategory.java
+++ b/src/main/java/gregicadditions/jei/GAMultiblockInfoCategory.java
@@ -32,7 +32,7 @@ public class GAMultiblockInfoCategory implements IRecipeCategory<MultiblockInfoR
 
 	@Override
 	public String getTitle() {
-		return I18n.format("gregtech.multiblock.title", new Object[0]);
+		return I18n.format("gregtech.multiblock.title");
 	}
 
 	@Override

--- a/src/main/java/gregicadditions/recipes/GAMachineRecipeRemoval.java
+++ b/src/main/java/gregicadditions/recipes/GAMachineRecipeRemoval.java
@@ -119,8 +119,6 @@ public class GAMachineRecipeRemoval {
 		removeRecipesByInputs(RecipeMaps.CUTTER_RECIPES, new ItemStack[] { new ItemStack(Blocks.QUARTZ_BLOCK) }, new FluidStack[] { Materials.Lubricant.getFluid(18) });
 		removeRecipesByInputs(RecipeMaps.CUTTER_RECIPES, new ItemStack[] { OreDictUnifier.get(OrePrefix.block, Materials.CertusQuartz) }, new FluidStack[] { Materials.Lubricant.getFluid(18) });
 
-		//Remove expensive Iridium recipe
-		removeRecipesByInputs(RecipeMaps.FUSION_RECIPES, Materials.Lithium.getFluid(16), Materials.Tungsten.getFluid(16));
 	}
 
 	private static <R extends RecipeBuilder<R>> void removeRecipesByInputs(RecipeMap<R> map, ItemStack... itemInputs) {

--- a/src/main/java/gregicadditions/recipes/GARecipeAddition.java
+++ b/src/main/java/gregicadditions/recipes/GARecipeAddition.java
@@ -524,7 +524,6 @@ public class GARecipeAddition {
 		RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Tantalum.getFluid(16), Materials.Tritium.getFluid(16)).fluidOutputs(Materials.Tungsten.getFluid(16)).duration(16).EUt(24576).EUToStart(200000000).buildAndRegister();
 		RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Silver.getFluid(16), Materials.Lithium.getFluid(16)).fluidOutputs(Materials.Indium.getFluid(16)).duration(32).EUt(24576).EUToStart(380000000).buildAndRegister();
 		RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.NaquadahEnriched.getFluid(15), Materials.Radon.getFluid(125)).fluidOutputs(Materials.Naquadria.getFluid(3)).duration(64).EUt(49152).EUToStart(400000000).buildAndRegister();
-		RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Lithium.getFluid(16), Materials.Tungsten.getFluid(16)).fluidOutputs(Materials.Iridium.getFluid(16)).duration(32).EUt(32768).EUToStart(300000000).buildAndRegister();
 		RecipeMaps.FUSION_RECIPES.recipeBuilder().fluidInputs(Materials.Lanthanum.getFluid(16), Materials.Silicon.getFluid(16)).fluidOutputs(Materials.Lutetium.getFluid(16)).duration(16).EUt(8192).EUToStart(80000000).buildAndRegister();
 
 		//Fusion Casing Recipes
@@ -537,6 +536,7 @@ public class GARecipeAddition {
 		//Explosive Recipes
 		ModHandler.removeRecipes(new ItemStack(Blocks.TNT));
 		ModHandler.removeRecipes(MetaItems.DYNAMITE.getStackForm());
+		RecipeMaps.CHEMICAL_RECIPES.recipeBuilder().duration(160).EUt(4).inputs(new ItemStack(Items.PAPER), new ItemStack(Items.STRING)).fluidInputs(Materials.Glyceryl.getFluid(500)).outputs(MetaItems.DYNAMITE.getStackForm()).buildAndRegister();
 		RecipeMaps.CHEMICAL_RECIPES.recipeBuilder().duration(160).EUt(4).inputs(new ItemStack(Items.PAPER), new ItemStack(Items.STRING)).fluidInputs(Materials.Glyceryl.getFluid(500)).outputs(MetaItems.DYNAMITE.getStackForm()).buildAndRegister();
 
 		//Lapotron Crystal Recipes

--- a/src/main/java/gregicadditions/recipes/GARecipeAddition.java
+++ b/src/main/java/gregicadditions/recipes/GARecipeAddition.java
@@ -537,7 +537,6 @@ public class GARecipeAddition {
 		ModHandler.removeRecipes(new ItemStack(Blocks.TNT));
 		ModHandler.removeRecipes(MetaItems.DYNAMITE.getStackForm());
 		RecipeMaps.CHEMICAL_RECIPES.recipeBuilder().duration(160).EUt(4).inputs(new ItemStack(Items.PAPER), new ItemStack(Items.STRING)).fluidInputs(Materials.Glyceryl.getFluid(500)).outputs(MetaItems.DYNAMITE.getStackForm()).buildAndRegister();
-		RecipeMaps.CHEMICAL_RECIPES.recipeBuilder().duration(160).EUt(4).inputs(new ItemStack(Items.PAPER), new ItemStack(Items.STRING)).fluidInputs(Materials.Glyceryl.getFluid(500)).outputs(MetaItems.DYNAMITE.getStackForm()).buildAndRegister();
 
 		//Lapotron Crystal Recipes
 		for (MaterialStack m : lapisLike) {

--- a/src/main/java/gregicadditions/recipes/GARecipeMaps.java
+++ b/src/main/java/gregicadditions/recipes/GARecipeMaps.java
@@ -24,8 +24,6 @@ public class GARecipeMaps {
 	@ZenProperty
 	public static final RecipeMap<SimpleRecipeBuilder> REPLICATOR_RECIPES;
 	@ZenProperty
-	public static final RecipeMap<SimpleRecipeBuilder> CRACKER_UNIT_RECIPES;
-	@ZenProperty
 	public static final RecipeMap<SimpleRecipeBuilder> PROCESSING_ARRAY_RECIPES;
 
 	static {
@@ -35,7 +33,6 @@ public class GARecipeMaps {
 		NAQUADAH_REACTOR_FUELS = new FuelRecipeMap("naquadah_reactor");
 		MASS_FAB_RECIPES = new RecipeMap<>("mass_fab", 0, 1, 0, 0, 0, 1, 1, 2, new SimpleRecipeBuilder()).setProgressBar(GuiTextures.PROGRESS_BAR_BENDING, ProgressWidget.MoveType.HORIZONTAL);
 		REPLICATOR_RECIPES = new RecipeMap<>("replicator", 0, 1, 0, 1, 1, 2, 0, 1, new SimpleRecipeBuilder()).setProgressBar(GuiTextures.PROGRESS_BAR_BENDING, ProgressWidget.MoveType.HORIZONTAL);
-		CRACKER_UNIT_RECIPES = new RecipeMap<>("cracker_unit", 0, 0, 0, 0, 2, 2, 1, 1, new SimpleRecipeBuilder());
 		PROCESSING_ARRAY_RECIPES = new RecipeMap<>("processing_array", 0, 9, 0, 6, 0, 3, 0, 2, new SimpleRecipeBuilder()).setProgressBar(GuiTextures.PROGRESS_BAR_BENDING, ProgressWidget.MoveType.HORIZONTAL);
 	}
 }

--- a/src/main/java/gregicadditions/recipes/GeneratorFuels.java
+++ b/src/main/java/gregicadditions/recipes/GeneratorFuels.java
@@ -17,7 +17,9 @@ public class GeneratorFuels {
 	public static void init() {
 		//Removal
 		removeFuelRecipe(RecipeMaps.DIESEL_GENERATOR_FUELS, Materials.LightFuel.getFluid(1));
-		removeFuelRecipe(RecipeMaps.SEMI_FLUID_GENERATOR_FUELS, Materials.Creosote.getFluid(2));
+		removeFuelRecipe(RecipeMaps.SEMI_FLUID_GENERATOR_FUELS, Materials.Creosote.getFluid(14));
+		removeFuelRecipe(RecipeMaps.SEMI_FLUID_GENERATOR_FUELS, Materials.OilLight.getFluid(64));
+		removeFuelRecipe(RecipeMaps.SEMI_FLUID_GENERATOR_FUELS, Materials.OilMedium.getFluid(32));
 		removeFuelRecipe(RecipeMaps.STEAM_TURBINE_FUELS, Materials.Steam.getFluid(60));
 
 		//Steam Turbine
@@ -41,9 +43,6 @@ public class GeneratorFuels {
 		FuelRecipes.registerSemiFluidGeneratorFuel(Materials.Biomass.getFluid(16), 1, GTValues.LV);
 		FuelRecipes.registerSemiFluidGeneratorFuel(Materials.OilLight.getFluid(32), 5, GTValues.LV);
 		FuelRecipes.registerSemiFluidGeneratorFuel(Materials.OilMedium.getFluid(64), 15, GTValues.LV);
-		FuelRecipes.registerSemiFluidGeneratorFuel(Materials.OilHeavy.getFluid(16), 5, GTValues.LV);
-		FuelRecipes.registerSemiFluidGeneratorFuel(Materials.SulfuricHeavyFuel.getFluid(16), 5, GTValues.LV);
-		FuelRecipes.registerSemiFluidGeneratorFuel(Materials.HeavyFuel.getFluid(8), 15, GTValues.LV);
 	}
 
 	//Register Methods

--- a/src/main/java/gregicadditions/recipes/GeneratorFuels.java
+++ b/src/main/java/gregicadditions/recipes/GeneratorFuels.java
@@ -17,11 +17,6 @@ public class GeneratorFuels {
 	public static void init() {
 		//Removal
 		removeFuelRecipe(RecipeMaps.DIESEL_GENERATOR_FUELS, Materials.LightFuel.getFluid(1));
-		//Note that GTCE currently adds Hydrogen to the gas generator twice. Once this is fixed, its removal and addition
-		//here can be removed, as the added recipe is the same as the GTCE one.
-		removeFuelRecipe(RecipeMaps.GAS_TURBINE_FUELS, Materials.Hydrogen.getFluid(1));
-		//Note, the same thing happens for Methane as for Hydrogen
-		removeFuelRecipe(RecipeMaps.GAS_TURBINE_FUELS, Materials.Methane.getFluid(1));
 		removeFuelRecipe(RecipeMaps.SEMI_FLUID_GENERATOR_FUELS, Materials.Creosote.getFluid(2));
 		removeFuelRecipe(RecipeMaps.STEAM_TURBINE_FUELS, Materials.Steam.getFluid(60));
 
@@ -29,8 +24,6 @@ public class GeneratorFuels {
 		FuelRecipes.registerSteamGeneratorFuel(Materials.Steam.getFluid(64), 1, GTValues.LV);
 
 		//Gas Turbine Fuels
-		FuelRecipes.registerGasGeneratorFuel(Materials.Hydrogen.getFluid(8), 5, GTValues.LV);
-		FuelRecipes.registerGasGeneratorFuel(Materials.Methane.getFluid(4), 14, GTValues.LV);
 		FuelRecipes.registerGasGeneratorFuel(Materials.RocketFuel.getFluid(16), 125, GTValues.LV);
 
 		//Diesel Generator Fluids

--- a/src/main/java/gregicadditions/recipes/GeneratorFuels.java
+++ b/src/main/java/gregicadditions/recipes/GeneratorFuels.java
@@ -3,6 +3,7 @@ package gregicadditions.recipes;
 import forestry.core.fluids.Fluids;
 import gregicadditions.GAConfig;
 import gregicadditions.GAMaterials;
+import gregicadditions.GregicAdditions;
 import gregtech.api.GTValues;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.recipes.machines.FuelRecipeMap;
@@ -15,71 +16,31 @@ import net.minecraftforge.fml.common.Loader;
 public class GeneratorFuels {
 	public static void init() {
 		//Removal
-		//removeFuelRecipe(RecipeMaps.DIESEL_GENERATOR_FUELS, Materials.BioFuel.getFluid(2));
 		removeFuelRecipe(RecipeMaps.DIESEL_GENERATOR_FUELS, Materials.LightFuel.getFluid(1));
-		removeFuelRecipe(RecipeMaps.DIESEL_GENERATOR_FUELS, Materials.LightFuel.getFluid(1));
-		removeFuelRecipe(RecipeMaps.DIESEL_GENERATOR_FUELS, Materials.Fuel.getFluid(1));
-		removeFuelRecipe(RecipeMaps.DIESEL_GENERATOR_FUELS, Materials.Ethanol.getFluid(2));
-		removeFuelRecipe(RecipeMaps.DIESEL_GENERATOR_FUELS, Materials.NitroFuel.getFluid(1));
-		removeFuelRecipe(RecipeMaps.DIESEL_GENERATOR_FUELS, Materials.Steam.getFluid(32));
+		//Note that GTCE currently adds Hydrogen to the gas generator twice. Once this is fixed, its removal and addition
+		//here can be removed, as the added recipe is the same as the GTCE one.
 		removeFuelRecipe(RecipeMaps.GAS_TURBINE_FUELS, Materials.Hydrogen.getFluid(1));
+		//Note, the same thing happens for Methane as for Hydrogen
 		removeFuelRecipe(RecipeMaps.GAS_TURBINE_FUELS, Materials.Methane.getFluid(1));
-		removeFuelRecipe(RecipeMaps.GAS_TURBINE_FUELS, Materials.LPG.getFluid(1));
-		removeFuelRecipe(RecipeMaps.GAS_TURBINE_FUELS, Materials.NaturalGas.getFluid(1));
 		removeFuelRecipe(RecipeMaps.SEMI_FLUID_GENERATOR_FUELS, Materials.Creosote.getFluid(2));
-		removeFuelRecipe(RecipeMaps.STEAM_TURBINE_FUELS, Materials.Steam.getFluid(32));
+		removeFuelRecipe(RecipeMaps.STEAM_TURBINE_FUELS, Materials.Steam.getFluid(60));
 
 		//Steam Turbine
 		FuelRecipes.registerSteamGeneratorFuel(Materials.Steam.getFluid(64), 1, GTValues.LV);
 
 		//Gas Turbine Fuels
-		FuelRecipes.registerGasGeneratorFuel(Materials.NaturalGas.getFluid(8), 5, GTValues.LV);
 		FuelRecipes.registerGasGeneratorFuel(Materials.Hydrogen.getFluid(8), 5, GTValues.LV);
-		FuelRecipes.registerGasGeneratorFuel(Materials.CarbonMonoxde.getFluid(8), 6, GTValues.LV);
-		FuelRecipes.registerGasGeneratorFuel(Materials.WoodGas.getFluid(8), 6, GTValues.LV);
-		FuelRecipes.registerGasGeneratorFuel(Materials.SulfuricGas.getFluid(32), 25, GTValues.LV);
-		FuelRecipes.registerGasGeneratorFuel(Materials.SulfuricNaphtha.getFluid(4), 5, GTValues.LV);
-		//FuelRecipes.registerGasGeneratorFuel(Materials.BioGas.getFluid(4), 45, GTValues.LV);
 		FuelRecipes.registerGasGeneratorFuel(Materials.Methane.getFluid(4), 14, GTValues.LV);
-		FuelRecipes.registerGasGeneratorFuel(Materials.Ethylene.getFluid(1), 4, GTValues.LV);
-		FuelRecipes.registerGasGeneratorFuel(Materials.Gas.getFluid(1), 5, GTValues.LV);
-		FuelRecipes.registerGasGeneratorFuel(Materials.Ethane.getFluid(4), 21, GTValues.LV);
-		FuelRecipes.registerGasGeneratorFuel(Materials.Propene.getFluid(1), 6, GTValues.LV);
-		FuelRecipes.registerGasGeneratorFuel(Materials.Butadiene.getFluid(16), 103, GTValues.LV);
-		FuelRecipes.registerGasGeneratorFuel(Materials.Propane.getFluid(4), 29, GTValues.LV);
 		FuelRecipes.registerGasGeneratorFuel(Materials.RocketFuel.getFluid(16), 125, GTValues.LV);
-		FuelRecipes.registerGasGeneratorFuel(Materials.Butene.getFluid(1), 8, GTValues.LV);
-		FuelRecipes.registerGasGeneratorFuel(Materials.Phenol.getFluid(1), 9, GTValues.LV);
-		FuelRecipes.registerGasGeneratorFuel(Materials.Benzene.getFluid(1), 9, GTValues.LV);
-		FuelRecipes.registerGasGeneratorFuel(Materials.Butane.getFluid(4), 37, GTValues.LV);
-		FuelRecipes.registerGasGeneratorFuel(Materials.LPG.getFluid(1), 10, GTValues.LV);
-		FuelRecipes.registerGasGeneratorFuel(Materials.Naphtha.getFluid(1), 10, GTValues.LV);
-		FuelRecipes.registerGasGeneratorFuel(Materials.Toluene.getFluid(4), 41, GTValues.LV);
 
 		//Diesel Generator Fluids
-		//FuelRecipes.registerDieselGeneratorFuel(Materials.BioFuel.getFluid(16), 3, GTValues.LV);
-		FuelRecipes.registerDieselGeneratorFuel(Materials.Oil.getFluid(2), 1, GTValues.LV);
-		FuelRecipes.registerDieselGeneratorFuel(Materials.SulfuricLightFuel.getFluid(4), 5, GTValues.LV);
-		FuelRecipes.registerDieselGeneratorFuel(Materials.Methanol.getFluid(8), 21, GTValues.LV);
 		FuelRecipes.registerDieselGeneratorFuel(Materials.RocketFuel.getFluid(2), 7, GTValues.LV);
-		if (Loader.isModLoaded("forestry") && GAConfig.Misc.ForestryIntegration) FuelRecipes.registerDieselGeneratorFuel(Fluids.BIO_ETHANOL.getFluid(1), 6, GTValues.LV);
-		else FuelRecipes.registerDieselGeneratorFuel(Materials.Ethanol.getFluid(1), 6, GTValues.LV);
-		FuelRecipes.registerDieselGeneratorFuel(Materials.BioDiesel.getFluid(1), 8, GTValues.LV);
 		FuelRecipes.registerDieselGeneratorFuel(Materials.LightFuel.getFluid(32), 305, GTValues.LV);
-		FuelRecipes.registerDieselGeneratorFuel(Materials.Fuel.getFluid(1), 15, GTValues.LV);
-		FuelRecipes.registerDieselGeneratorFuel(Materials.NitroFuel.getFluid(2), 45, GTValues.LV);
 
 		//Naquadah Reactor
 		registerNaquadahReactorFuel(Materials.NaquadahEnriched.getFluid(1), 750, GTValues.LV);
 
-		//Plasma Generator
-		registerPlasmaFuel(Materials.Helium.getPlasma(1), 2560, GTValues.LV);
-		registerPlasmaFuel(Materials.Nitrogen.getPlasma(1), 4032, GTValues.LV);
-		registerPlasmaFuel(Materials.Oxygen.getPlasma(1), 4096, GTValues.LV);
-		registerPlasmaFuel(Materials.Iron.getPlasma(16), 103219, GTValues.LV);
-		registerPlasmaFuel(Materials.Nickel.getPlasma(16), 106905, GTValues.LV);
-
-		//Smefuels
+		//Semifuels
 		FuelRecipes.registerSemiFluidGeneratorFuel(GAMaterials.FISH_OIL.getFluid(64), 1, GTValues.LV);
 		if (Loader.isModLoaded("forestry") && GAConfig.Misc.ForestryIntegration) FuelRecipes.registerSemiFluidGeneratorFuel(Fluids.SEED_OIL.getFluid(64), 1, GTValues.LV);
 		else FuelRecipes.registerSemiFluidGeneratorFuel(Materials.SeedOil.getFluid(64), 1, GTValues.LV);
@@ -103,6 +64,11 @@ public class GeneratorFuels {
 	}
 
 	private static void removeFuelRecipe(FuelRecipeMap map, FluidStack fluidStack) {
-		map.removeRecipe(map.findRecipe(Integer.MAX_VALUE, fluidStack));
+		if(map.removeRecipe(map.findRecipe(Integer.MAX_VALUE, fluidStack))) {
+			GregicAdditions.LOGGER.info("Removed Generator Recipe for " + map.getLocalizedName() + " for Fluid: " + fluidStack.getLocalizedName());
+		}
+		else {
+			GregicAdditions.LOGGER.warn("Failed to remove Generator Recipe for " + map.getLocalizedName() + " for Fluid: " + fluidStack.getLocalizedName());
+		}
 	}
 }


### PR DESCRIPTION
Cleans up the additions and removals to the Generator/Turbine Recipe Maps.

Most additions have been moved into GTCE itself, see this file [here](https://github.com/GregTechCE/GregTech/blob/master/src/main/java/gregtech/loaders/recipe/FuelRecipes.java), therefore having them added here is not needed. 

In the process of this cleanup, I discovered https://github.com/GregTechCE/GregTech/issues/1377 and reported it, and so deferred the removal of the Hydrogen and Methane recipes until the issue was fixed in GTCE, to prevent any weirdness with the recipes.

The removal of Steam in the Steam Turbine was fixed, so that the added recipe by SoG could take importance.

In addition, removes the creation of the Cracker Unit recipe map, as all implementation of the cracker unit in SoG was removed in #7, and we should access the RecipeMap through GTCE if we need it.