### PR TITLE
Let processing array attempt to use cached previousRecipe like other machines

### DIFF
--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -430,7 +430,7 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 			if (dirty || forceRecipeRecheck) {
 				String oldMachine = this.machineName;
 				int oldTier = this.machineTierVoltage;
-				if (!findMachine(importInventory, importFluids).equals(oldMachine) || oldTier != this.machineTierVoltage) {
+				if (!findMachine(importInventory).equals(oldMachine) || oldTier != this.machineTierVoltage) {
 					// available machines changed, don't use cached recipe without rechecking
 					previousRecipe = null;
 				}

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -437,7 +437,7 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 			}
 
 			if (previousRecipe != null &&
-                previousRecipe.matches(false, importInventory, importFluids)) {
+				previousRecipe.matches(false, importInventory, importFluids)) {
 				// if previous recipe still matches inputs, try to use it
 				currentRecipe = previousRecipe;
 			} else if (dirty || forceRecipeRecheck) {

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -427,7 +427,20 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 			IMultipleTankHandler importFluids = getInputTank();
 
 			boolean dirty = checkRecipeInputsDirty(importInventory, importFluids);
-			if(dirty || forceRecipeRecheck) {
+			if (dirty || forceRecipeRecheck) {
+				String oldMachine = this.machineName;
+				int oldTier = this.machineTierVoltage;
+				if (!findMachine(importInventory, importFluids).equals(oldMachine) || oldTier != this.machineTierVoltage) {
+					// available machines changed, don't use cached recipe without rechecking
+					previousRecipe = null;
+				}
+			}
+
+			if (previousRecipe != null &&
+                previousRecipe.matches(false, importInventory, importFluids)) {
+				// if previous recipe still matches inputs, try to use it
+				currentRecipe = previousRecipe;
+			} else if (dirty || forceRecipeRecheck) {
 				this.forceRecipeRecheck = false;
 
 				// else, try searching new recipe for given inputs
@@ -435,11 +448,6 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 
 				if(currentRecipe != null)
 					this.previousRecipe = currentRecipe;
-
-			} else if(previousRecipe != null &&
-				previousRecipe.matches(false, importInventory, importFluids)) {
-				// if previous recipe still matches inputs, try to use it
-				currentRecipe = previousRecipe;
 			}
 			if(currentRecipe != null && setupAndConsumeRecipeInputs(currentRecipe))
 				setupRecipe(currentRecipe);


### PR DESCRIPTION
The extra problem here is the machines being replaced, so we do
still recheck those whenever the inventory changed.

machineName + machineTierVoltage is sufficient at the moment since that's all that is used, but machineItemStack might be better, I just wasn't 100% sure what the mutability / equality risks were there.

The symptom to fix is large tick time usage - a PA with 16 IV macerators and a UV input bus full of cobblestone would take ~20ms due to the Recipe.matches being particularly slow when failing to match with a large input inventory. (Fixing that might not be a bad idea, but would be a lot harder, and probably would require API changes for a real benefit)