### PR TITLE
Don't register materials when disabled in the config

### DIFF
--- a/src/main/java/gregicadditions/GAConfig.java
+++ b/src/main/java/gregicadditions/GAConfig.java
@@ -41,10 +41,6 @@ public class GAConfig {
 		@Config.Name("Should Electrodes be registered?")
 		public boolean electrodes = true;
 
-		@Config.Comment("Set this to false to disable rounds")
-		@Config.Name("Should rounds be registered?")
-		public boolean addRounds = true;
-
 		@Config.Comment("Set this to false to disable double ingots")
 		@Config.Name("Should double ingots be registered?")
 		public boolean addDoubleIngots = true;

--- a/src/main/java/gregicadditions/GAEnums.java
+++ b/src/main/java/gregicadditions/GAEnums.java
@@ -30,10 +30,8 @@ public class GAEnums {
 			EnumHelper.addEnum(OrePrefix.class, "ingotDouble", new Class[] { String.class, long.class, Material.class, MaterialIconType.class, long.class, Predicate.class }, "Double Ingot", GTValues.M, null, MaterialIconType.valueOf("ingotDouble"), OrePrefix.Flags.ENABLE_UNIFICATION, pred(mat -> ingot.test(mat) && mat.hasFlag(DustMaterial.MatFlags.GENERATE_PLATE)));
 		}
 
-		if (GAConfig.GT6.addRounds) {
-			EnumHelper.addEnum(MaterialIconType.class, "round", new Class[0]);
-			EnumHelper.addEnum(OrePrefix.class, "round", new Class[] { String.class, long.class, Material.class, MaterialIconType.class, long.class, Predicate.class }, "Round", GTValues.M, null, MaterialIconType.valueOf("round"), OrePrefix.Flags.ENABLE_UNIFICATION, pred(mat -> ingot.test(mat) && mat.hasFlag(IngotMaterial.MatFlags.GENERATE_SMALL_GEAR)));
-		}
+		EnumHelper.addEnum(MaterialIconType.class, "round", new Class[0]);
+		EnumHelper.addEnum(OrePrefix.class, "round", new Class[] { String.class, long.class, Material.class, MaterialIconType.class, long.class, Predicate.class }, "Round", GTValues.M, null, MaterialIconType.valueOf("round"), OrePrefix.Flags.ENABLE_UNIFICATION, pred(mat -> ingot.test(mat) && mat.hasFlag(IngotMaterial.MatFlags.GENERATE_SMALL_GEAR)));
 	}
 
 	public static final Predicate<Material> dust = mat -> mat instanceof DustMaterial;

--- a/src/main/java/gregicadditions/item/GAMetaItem.java
+++ b/src/main/java/gregicadditions/item/GAMetaItem.java
@@ -14,8 +14,8 @@ import net.minecraftforge.fml.common.Loader;
 
 public class GAMetaItem extends MaterialMetaItem {
 
-	public GAMetaItem() {
-		super(OrePrefix.valueOf("plateCurved"), OrePrefix.valueOf("ingotDouble"), OrePrefix.valueOf("round"), null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+	public GAMetaItem(OrePrefix[] prefixes) {
+		super(prefixes);
 	}
 
 	@Override

--- a/src/main/java/gregicadditions/item/GAMetaItems.java
+++ b/src/main/java/gregicadditions/item/GAMetaItems.java
@@ -67,12 +67,10 @@ public class GAMetaItems {
 		}
 
 		if(GAConfig.GT6.addDoubleIngots) {
-			temp[1] = OrePrefix.valueOf("plateDouble");
+			temp[1] = OrePrefix.valueOf("ingotDouble");
 		}
 
-		if(GAConfig.GT6.addRounds) {
-			temp[2] = OrePrefix.valueOf("round");
-		}
+		temp[2] = OrePrefix.valueOf("round");
 
 		return temp;
 	}

--- a/src/main/java/gregicadditions/item/GAMetaItems.java
+++ b/src/main/java/gregicadditions/item/GAMetaItems.java
@@ -2,8 +2,10 @@ package gregicadditions.item;
 
 import java.util.List;
 
+import gregicadditions.GAConfig;
 import gregicadditions.GregicAdditions;
 import gregtech.api.items.metaitem.MetaItem;
+import gregtech.api.unification.ore.OrePrefix;
 import gregtech.common.items.MetaItems;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
@@ -51,10 +53,28 @@ public class GAMetaItems {
 	public static MetaItem<?>.MetaValueItem STEM_CELLS;
 
 	public static void init() {
-		GAMetaItem item = new GAMetaItem();
+		GAMetaItem item = new GAMetaItem(gatherRegisteredPrefixes());
 		item.setRegistryName("ga_meta_item");
 		GAMetaTool tool = new GAMetaTool();
 		tool.setRegistryName("ga_meta_tool");
+	}
+
+	public static OrePrefix[] gatherRegisteredPrefixes() {
+		OrePrefix[] temp = new OrePrefix[32];
+
+		if(GAConfig.GT6.addCurvedPlates) {
+			temp[0] = OrePrefix.valueOf("plateCurved");
+		}
+
+		if(GAConfig.GT6.addDoubleIngots) {
+			temp[1] = OrePrefix.valueOf("plateDouble");
+		}
+
+		if(GAConfig.GT6.addRounds) {
+			temp[2] = OrePrefix.valueOf("round");
+		}
+
+		return temp;
 	}
 
 	public static void registerOreDict() {

--- a/src/main/java/gregicadditions/recipes/GAMachineRecipeRemoval.java
+++ b/src/main/java/gregicadditions/recipes/GAMachineRecipeRemoval.java
@@ -44,7 +44,7 @@ public class GAMachineRecipeRemoval {
 			}
 
 			//Remove Old Rotor Recipe
-			if (!OreDictUnifier.get(OrePrefix.rotor, m).isEmpty() && GAConfig.GT6.BendingRotors && GAConfig.GT6.BendingCylinders) removeRecipesByInputs(RecipeMaps.ASSEMBLER_RECIPES, OreDictUnifier.get(OrePrefix.plate, m, 4), OreDictUnifier.get(OrePrefix.ring, m));
+			if (!OreDictUnifier.get(OrePrefix.rotor, m).isEmpty() && !OreDictUnifier.get(OrePrefix.valueOf("plateCurved"), m).isEmpty() && GAConfig.GT6.BendingRotors && GAConfig.GT6.BendingCylinders) removeRecipesByInputs(RecipeMaps.ASSEMBLER_RECIPES, OreDictUnifier.get(OrePrefix.plate, m, 4), OreDictUnifier.get(OrePrefix.ring, m));
 
 			//Remove Old Wrench Recipes
 			if (m instanceof IngotMaterial && !m.hasFlag(DustMaterial.MatFlags.NO_SMASHING) && GAConfig.GT6.ExpensiveWrenches) {
@@ -71,7 +71,7 @@ public class GAMachineRecipeRemoval {
 		}
 
 		//Remove Old Bucket Recipe
-		if (GAConfig.GT6.BendingCurvedPlates) {
+		if (GAConfig.GT6.BendingCurvedPlates && GAConfig.GT6.addCurvedPlates) {
 			removeRecipesByInputs(RecipeMaps.BENDER_RECIPES, OreDictUnifier.get(OrePrefix.plate, Materials.Iron, 12), IntCircuitIngredient.getIntegratedCircuit(1));
 			removeRecipesByInputs(RecipeMaps.BENDER_RECIPES, OreDictUnifier.get(OrePrefix.plate, Materials.WroughtIron, 12), IntCircuitIngredient.getIntegratedCircuit(1));
 		}

--- a/src/main/java/gregicadditions/recipes/GARecipeAddition.java
+++ b/src/main/java/gregicadditions/recipes/GARecipeAddition.java
@@ -89,7 +89,7 @@ public class GARecipeAddition {
 		RecipeMaps.FORGE_HAMMER_RECIPES.recipeBuilder().inputs(new ItemStack(Items.BONE)).outputs(new ItemStack(Items.DYE, 4, 15)).duration(16).EUt(10).buildAndRegister();
 
 		//GT6 Bending
-		if (GAConfig.GT6.BendingCurvedPlates && GAConfig.GT6.BendingCylinders) {
+		if (GAConfig.GT6.BendingCurvedPlates && GAConfig.GT6.BendingCylinders && GAConfig.GT6.addCurvedPlates) {
 			ModHandler.removeRecipeByName(new ResourceLocation("gregtech:iron_bucket"));
 			ModHandler.addShapedRecipe("bucket", new ItemStack(Items.BUCKET), "ChC", " P ", 'C', "plateCurvedIron", 'P', "plateIron");
 			RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().duration(200).EUt(4).input(OrePrefix.valueOf("plateCurved"), Materials.Iron, 2).input(OrePrefix.plate, Materials.Iron).outputs(new ItemStack(Items.BUCKET)).buildAndRegister();
@@ -125,7 +125,7 @@ public class GARecipeAddition {
 				ModHandler.addShapedRecipe("flatten_plate_" + m.toString(), OreDictUnifier.get(OrePrefix.plate, m), "h", "C", 'C', new UnificationEntry(OrePrefix.valueOf("plateCurved"), m));
 				RecipeMaps.BENDER_RECIPES.recipeBuilder().EUt(24).duration((int) m.getMass()).input(OrePrefix.plate, m).circuitMeta(0).outputs(OreDictUnifier.get(OrePrefix.valueOf("plateCurved"), m)).buildAndRegister();
 			}
-			if (!OreDictUnifier.get(OrePrefix.rotor, m).isEmpty() && GAConfig.GT6.BendingRotors && GAConfig.GT6.BendingCylinders) {
+			if (!OreDictUnifier.get(OrePrefix.rotor, m).isEmpty() && !OreDictUnifier.get(OrePrefix.valueOf("plateCurved"), m).isEmpty() && GAConfig.GT6.BendingRotors && GAConfig.GT6.BendingCylinders) {
 				ModHandler.removeRecipes(OreDictUnifier.get(OrePrefix.rotor, m));
 				ModHandler.addShapedRecipe("ga_rotor_" + m.toString(), OreDictUnifier.get(OrePrefix.rotor, m), "ChC", "SRf", "CdC", 'C', OreDictUnifier.get(OrePrefix.valueOf("plateCurved"), m), 'S', OreDictUnifier.get(OrePrefix.screw, m), 'R', OreDictUnifier.get(OrePrefix.ring, m));
 				RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().duration(240).EUt(24).inputs(OreDictUnifier.get(OrePrefix.valueOf("plateCurved"), m, 4), OreDictUnifier.get(OrePrefix.ring, m)).fluidInputs(Materials.SolderingAlloy.getFluid(32)).outputs(OreDictUnifier.get(OrePrefix.rotor, m)).buildAndRegister();
@@ -148,7 +148,7 @@ public class GARecipeAddition {
 			}
 
 
-			if (GAConfig.GT6.BendingPipes && GAConfig.GT6.BendingCylinders) {
+			if (GAConfig.GT6.BendingPipes && GAConfig.GT6.BendingCylinders && GAConfig.GT6.addCurvedPlates) {
 				ModHandler.removeRecipes(OreDictUnifier.get(OrePrefix.pipeSmall, Materials.Wood));
 				ModHandler.removeRecipes(OreDictUnifier.get(OrePrefix.pipeMedium, Materials.Wood));
 				ModHandler.addShapedRecipe("pipe_ga_wood", OreDictUnifier.get(OrePrefix.pipeMedium, Materials.Wood, 2), "PPP", "sCh", "PPP", 'P', "plankWood", 'C', "craftingToolBendingCylinder");
@@ -216,7 +216,7 @@ public class GARecipeAddition {
 
 		//Pipes
 		for (Material m : Material.MATERIAL_REGISTRY) {
-			if (!OreDictUnifier.get(OrePrefix.pipeMedium, m).isEmpty() && GAConfig.GT6.BendingPipes) {
+			if (!OreDictUnifier.get(OrePrefix.pipeMedium, m).isEmpty() && !OreDictUnifier.get(OrePrefix.valueOf("plateCurved"), m).isEmpty() && GAConfig.GT6.BendingPipes) {
 				ModHandler.removeRecipeByName(new ResourceLocation("gregtech:small_" + m.toString() + "_pipe"));
 				ModHandler.removeRecipeByName(new ResourceLocation("gregtech:medium_" + m.toString() + "_pipe"));
 				ModHandler.removeRecipeByName(new ResourceLocation("gregtech:large_" + m.toString() + "_pipe"));

--- a/src/main/java/gregicadditions/recipes/MachineCraftingRecipes.java
+++ b/src/main/java/gregicadditions/recipes/MachineCraftingRecipes.java
@@ -239,7 +239,7 @@ public class MachineCraftingRecipes {
 		
 		if (GAConfig.GT6.registerDums) {
 			ModHandler.addShapedRecipe("wooden_barrel", GATileEntities.WOODEN_DRUM.getStackForm(), "rSs", "PRP", "PRP", 'S', "slimeball", 'P', "plankWood", 'R', "stickLongIron");
-			if (GAConfig.GT6.BendingCurvedPlates && GAConfig.GT6.BendingCylinders) {
+			if (GAConfig.GT6.BendingCurvedPlates && GAConfig.GT6.BendingCylinders && GAConfig.GT6.addCurvedPlates) {
 				ModHandler.addShapedRecipe("bronze_drum", GATileEntities.BRONZE_DRUM.getStackForm(), " h ", "PRP", "PRP", 'P', "plateCurvedBronze", 'R', "stickLongBronze");
 				ModHandler.addShapedRecipe("steel_drum", GATileEntities.STEEL_DRUM.getStackForm(), " h ", "PRP", "PRP", 'P', "plateCurvedSteel", 'R', "stickLongSteel");
 				ModHandler.addShapedRecipe("stainless_steel_drum", GATileEntities.STAINLESS_STEEL_DRUM.getStackForm(), " h ", "PRP", "PRP", 'P', "plateCurvedStainlessSteel", 'R', "stickLongStainlessSteel");


### PR DESCRIPTION
This changes things so that when Double Plates, Curved Ingots, or Rounds are not enabled via the config, they will not show up in JEI. This is done so that the materials don't have to be hidden from JEI separately after being disabled in the config.

In addition, some more precautions were taken when registering recipes that before assumed that these materials would exist in JEI to check if the materials were actually registered or not.