### PR TITLE
Stop registering recipes if the Forestry bee module was disabled

### DIFF
--- a/src/main/java/gregicadditions/bees/CommonProxy.java
+++ b/src/main/java/gregicadditions/bees/CommonProxy.java
@@ -31,7 +31,7 @@ public class CommonProxy {
 	}
 
 	public void postInit() {
-		if (!GAConfig.GTBees.EnableGTCEBees || !Loader.isModLoaded("forestry")) return;
+		if (!GAConfig.GTBees.EnableGTCEBees || !Loader.isModLoaded("forestry") || !ForestryAPI.enabledModules.contains(new ResourceLocation("forestry","apiculture"))) return;
 		if (GAConfig.GTBees.GenerateCentrifugeRecipes) for (ICentrifugeRecipe recipe : RecipeManagers.centrifugeManager.recipes()) {
 			SimpleRecipeBuilder builder = RecipeMaps.CENTRIFUGE_RECIPES.recipeBuilder();
 			builder.inputs(recipe.getInput().copy());


### PR DESCRIPTION
This prevents invalid recipes from showing up in JEI due to the fact that the Bee module in Forestry was disabled, which prevents the registration of the items used in the recipes.

To see a current example of this issue, look up the used for Crushed Aluminum Ore, when the Forestry Bee module is disabled, but the SoG bee module is enabled.