### PR TITLE
Update Gregtech CE to 1.11.1.632

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     deobfCompile "mezz.jei:jei_1.12.2:+"
 	deobfCompile "mcp.mobius.waila:Hwyla:1.8+"
     deobfCompile "net.sengir.forestry:forestry_1.12.2:+"
-	deobfCompile "gregtechce:gregtech:1.12.2:1.10.1.557"
+	deobfCompile "gregtechce:gregtech:1.12.2:1.11.1.632"
 	deobfCompile "codechicken:ChickenASM:1.12-+"
     deobfCompile "codechicken-lib-1-8:CodeChickenLib-1.12.2:3.2.3.357:universal"
     deobfCompile "forge-multipart-cbe:ForgeMultipart-1.12.2:2.6.2.83:universal"

--- a/src/main/java/gregicadditions/recipes/GAMachineRecipeRemoval.java
+++ b/src/main/java/gregicadditions/recipes/GAMachineRecipeRemoval.java
@@ -43,9 +43,6 @@ public class GAMachineRecipeRemoval {
 				removeRecipesByInputs(RecipeMaps.BENDER_RECIPES, OreDictUnifier.get(OrePrefix.plate, m), IntCircuitIngredient.getIntegratedCircuit(0));
 			}
 
-			//Remove Old Rotor Recipe
-			if (!OreDictUnifier.get(OrePrefix.rotor, m).isEmpty() && GAConfig.GT6.BendingRotors && GAConfig.GT6.BendingCylinders) removeRecipesByInputs(RecipeMaps.ASSEMBLER_RECIPES, OreDictUnifier.get(OrePrefix.plate, m, 4), OreDictUnifier.get(OrePrefix.ring, m));
-
 			//Remove Old Wrench Recipes
 			if (m instanceof IngotMaterial && !m.hasFlag(DustMaterial.MatFlags.NO_SMASHING) && GAConfig.GT6.ExpensiveWrenches) {
 				ModHandler.removeRecipeByName(new ResourceLocation(String.format("gregtech:wrench_%s", m.toString())));
@@ -83,9 +80,6 @@ public class GAMachineRecipeRemoval {
 		removeRecipesByInputs(RecipeMaps.ASSEMBLER_RECIPES, MetaItems.ENERGY_LAPOTRONIC_ORB2.getStackForm(8), OreDictUnifier.get(OrePrefix.plate, Materials.Darmstadtium, 16));
 		ModHandler.removeRecipeByName(new ResourceLocation("gregtech:primitive_circuit"));
 
-		//Circuit Rabbit Hole-Related Recipe Removal
-		removeRecipesByInputs(RecipeMaps.CHEMICAL_RECIPES, new ItemStack[] { OreDictUnifier.get(OrePrefix.dust, Materials.Silicon) }, new FluidStack[] { Materials.Epichlorhydrin.getFluid(144) });
-
 		//Remove GT5 Ash Centrifuging
 		removeRecipesByInputs(RecipeMaps.CENTRIFUGE_RECIPES, OreDictUnifier.get(OrePrefix.dust, Materials.DarkAsh, 2));
 		removeRecipesByInputs(RecipeMaps.CENTRIFUGE_RECIPES, OreDictUnifier.get(OrePrefix.dust, Materials.Ash));
@@ -103,10 +97,12 @@ public class GAMachineRecipeRemoval {
 		//Remove Cheap Diesel Recipe
 		removeRecipesByInputs(RecipeMaps.MIXER_RECIPES, Materials.LightFuel.getFluid(5000), Materials.HeavyFuel.getFluid(1000));
 
-		//Fix Seed Oil Recipe
-		removeRecipesByInputs(RecipeMaps.FLUID_EXTRACTION_RECIPES, new ItemStack(Items.WHEAT_SEEDS));
-		removeRecipesByInputs(RecipeMaps.FLUID_EXTRACTION_RECIPES, new ItemStack(Items.MELON_SEEDS));
-		removeRecipesByInputs(RecipeMaps.FLUID_EXTRACTION_RECIPES, new ItemStack(Items.PUMPKIN_SEEDS));
+		//Remove duplicate seed oil recipes if we are generating our own
+		if(GAConfig.GTBees.GenerateExtractorRecipes) {
+			removeRecipesByInputs(RecipeMaps.FLUID_EXTRACTION_RECIPES, new ItemStack(Items.WHEAT_SEEDS));
+			removeRecipesByInputs(RecipeMaps.FLUID_EXTRACTION_RECIPES, new ItemStack(Items.MELON_SEEDS));
+			removeRecipesByInputs(RecipeMaps.FLUID_EXTRACTION_RECIPES, new ItemStack(Items.PUMPKIN_SEEDS));
+		}
 
 		//Remove Conflicting Redstone Plate Recipe
 		removeRecipesByInputs(RecipeMaps.COMPRESSOR_RECIPES, OreDictUnifier.get(OrePrefix.dust, Materials.Redstone));
@@ -135,7 +131,7 @@ public class GAMachineRecipeRemoval {
 			GregicAdditions.LOGGER.info("Removed Recipe for Item Input(s): " + names);
 		}
 		else {
-			GregicAdditions.LOGGER.info("Failed to Remove Recipe for Item Input(s): " + names);
+			GregicAdditions.LOGGER.warn("Failed to Remove Recipe for Item Input(s): " + names);
 		}
 	}
 
@@ -151,7 +147,7 @@ public class GAMachineRecipeRemoval {
 			GregicAdditions.LOGGER.info("Removed Recipe for Fluid Input(s): " + names);
 		}
 		else {
-			GregicAdditions.LOGGER.info("Failed to Remove Recipe for Fluid Input(s): " + names);
+			GregicAdditions.LOGGER.warn("Failed to Remove Recipe for Fluid Input(s): " + names);
 		}
 	}
 

--- a/src/main/java/gregicadditions/recipes/GARecipeAddition.java
+++ b/src/main/java/gregicadditions/recipes/GARecipeAddition.java
@@ -546,16 +546,6 @@ public class GARecipeAddition {
 			ModHandler.addShapelessRecipe("lapotron_crystal_shapeless" + gem.toString(), MetaItems.LAPOTRON_CRYSTAL.getStackForm(), OreDictUnifier.get(OrePrefix.gemExquisite, Materials.Sapphire), OreDictUnifier.get(OrePrefix.stick, gem), MetaItems.CAPACITOR.getStackForm());
 		}
 
-		//Add Missing Superconducter Wire Tiering Recipes
-		ModHandler.addShapelessRecipe("superonducter_wire_gtsingle_doubling", OreDictUnifier.get(OrePrefix.wireGtDouble, Tier.Superconductor), OreDictUnifier.get(OrePrefix.wireGtSingle, Tier.Superconductor), OreDictUnifier.get(OrePrefix.wireGtSingle, Tier.Superconductor));
-		ModHandler.addShapelessRecipe("superonducter_wire_gtdouble_doubling", OreDictUnifier.get(OrePrefix.wireGtQuadruple, Tier.Superconductor), OreDictUnifier.get(OrePrefix.wireGtDouble, Tier.Superconductor), OreDictUnifier.get(OrePrefix.wireGtDouble, Tier.Superconductor));
-		ModHandler.addShapelessRecipe("superonducter_wire_gtquadruple_doubling", OreDictUnifier.get(OrePrefix.wireGtOctal, Tier.Superconductor), OreDictUnifier.get(OrePrefix.wireGtQuadruple, Tier.Superconductor), OreDictUnifier.get(OrePrefix.wireGtQuadruple, Tier.Superconductor));
-		ModHandler.addShapelessRecipe("superonducter_wire_gtoctal_doubling", OreDictUnifier.get(OrePrefix.wireGtHex, Tier.Superconductor), OreDictUnifier.get(OrePrefix.wireGtOctal, Tier.Superconductor), OreDictUnifier.get(OrePrefix.wireGtOctal, Tier.Superconductor));
-		ModHandler.addShapelessRecipe("superonducter_wire_gtdouble_splitting", OreDictUnifier.get(OrePrefix.wireGtSingle, Tier.Superconductor, 2), OreDictUnifier.get(OrePrefix.wireGtDouble, Tier.Superconductor));
-		ModHandler.addShapelessRecipe("superonducter_wire_gtquadruple_splitting", OreDictUnifier.get(OrePrefix.wireGtDouble, Tier.Superconductor, 2), OreDictUnifier.get(OrePrefix.wireGtQuadruple, Tier.Superconductor));
-		ModHandler.addShapelessRecipe("superonducter_wire_gtoctal_splitting", OreDictUnifier.get(OrePrefix.wireGtQuadruple, Tier.Superconductor, 2), OreDictUnifier.get(OrePrefix.wireGtOctal, Tier.Superconductor));
-		ModHandler.addShapelessRecipe("superonducter_wire_gthex_splitting", OreDictUnifier.get(OrePrefix.wireGtOctal, Tier.Superconductor, 2), OreDictUnifier.get(OrePrefix.wireGtHex, Tier.Superconductor));
-
 		//Dust Packing
 		for (Material m : Material.MATERIAL_REGISTRY) {
 			if (!OreDictUnifier.get(OrePrefix.dust, m).isEmpty() && GAConfig.Misc.PackagerDustRecipes) {
@@ -761,10 +751,8 @@ public class GARecipeAddition {
 
 		if (GAConfig.GT5U.GenerateCompressorRecipes) {
 			ModHandler.removeRecipeByName(new ResourceLocation("minecraft:glowstone"));
-			ModHandler.removeRecipeByName(new ResourceLocation("gregtech:block_compress_glowstone"));
 			ModHandler.removeRecipeByName(new ResourceLocation("minecraft:quartz_block"));
-			ModHandler.removeRecipeByName(new ResourceLocation("gregtech:block_compress_nether_quartz"));
-			ModHandler.removeRecipeByName(new ResourceLocation("gregtech:block_decompress_nether_quartz"));
+			ModHandler.removeRecipeByName(new ResourceLocation("gregtech:nether_quartz_block_to_nether_quartz"));
 			RecipeMaps.FORGE_HAMMER_RECIPES.recipeBuilder().duration(100).EUt(24).inputs(OreDictUnifier.get(OrePrefix.block, Materials.NetherQuartz)).outputs(OreDictUnifier.get(OrePrefix.gem, Materials.NetherQuartz, 4)).buildAndRegister();
 		}
 


### PR DESCRIPTION
Updates the Gregtech CE dependency to 1.11.1.632

Changes since the previous depended on version:

- Rotor's recipes in the assembler have been removed, so stop trying to remove them. However, I kept the recipes in with Curved Plates, if those were enabled, as it presents an option to make rotors in a machine at LV.
- Removes the removal of a Silicone Rubber recipe, as it was removed in the chemistry update
- Since the duplicate seed oil recipe was removed, first check if we are going to be adding seed oil recipes due to our Forestry compat, so that Seed oil recipes for the three seeds remains if we are not adding recipes
- Remove duplicate superconductor wire recipes discovered while checking the impact of the wire changes
- Remove some no longer needed block compress/decompress recipe removals, and update an existing one (After 1.9.4/1.10.5)