### PR TITLE
Fix Coloring of Bending Cylinders

### DIFF
--- a/src/main/resources/assets/gregtech/models/item/tools/bending_cylinder.json
+++ b/src/main/resources/assets/gregtech/models/item/tools/bending_cylinder.json
@@ -2,8 +2,8 @@
   "parent": "item/generated",
   "textures": {
     "layer0": "gregtech:items/void",
-    "layer1": "gregtech:items/void",
-    "layer2": "gregtech:items/tools/bending_cylinder",
+    "layer1": "gregtech:items/tools/bending_cylinder",
+    "layer2": "gregtech:items/void",
     "layer3": "gregtech:items/void"
   }
 }

--- a/src/main/resources/assets/gregtech/models/item/tools/bending_cylinder_small.json
+++ b/src/main/resources/assets/gregtech/models/item/tools/bending_cylinder_small.json
@@ -2,8 +2,8 @@
   "parent": "item/generated",
   "textures": {
     "layer0": "gregtech:items/void",
-    "layer1": "gregtech:items/void",
-    "layer2": "gregtech:items/tools/bending_cylinder_small",
+    "layer1": "gregtech:items/tools/bending_cylinder_small",
+    "layer2": "gregtech:items/void",
     "layer3": "gregtech:items/void"
   }
 }


### PR DESCRIPTION
Bending Cylinders did not use the proper material coloring due to how the model layers were declared. A snippet of code from GTCE that shows how the coloring of the overlay behaves, from `IToolStats`:
```
default int getColor(ItemStack stack, int tintIndex) {
        SolidMaterial primaryMaterial = ToolMetaItem.getToolMaterial(stack);
        return tintIndex % 2 == 1 ? primaryMaterial.materialRGB : 0xFFFFFF;
    }
```
You can see in this code that the rendered layer must be an odd number. I moved the layer to be on `layer1` rather than `layer2` for both Bending Cylinders.

Before:
![before](https://user-images.githubusercontent.com/10861407/108653777-f5063400-748c-11eb-8aae-10bf784ab6c8.PNG)

After:
![after](https://user-images.githubusercontent.com/10861407/108653779-f8012480-748c-11eb-903e-f31c048a1246.PNG)