### PR TITLE
Update GTCE dependency and fix Multiblock Previews

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     deobfCompile "mezz.jei:jei_1.12.2:+"
 	deobfCompile "mcp.mobius.waila:Hwyla:1.8+"
     deobfCompile "net.sengir.forestry:forestry_1.12.2:+"
-	deobfCompile "gregtechce:gregtech:1.12.2:1.11.1.632"
+	deobfCompile "gregtechce:gregtech:1.12.2:1.12.0.662"
 	deobfCompile "codechicken:ChickenASM:1.12-+"
     deobfCompile "codechicken-lib-1-8:CodeChickenLib-1.12.2:3.2.3.357:universal"
     deobfCompile "forge-multipart-cbe:ForgeMultipart-1.12.2:2.6.2.83:universal"

--- a/src/main/java/gregicadditions/jei/GAMultiblockInfoCategory.java
+++ b/src/main/java/gregicadditions/jei/GAMultiblockInfoCategory.java
@@ -3,6 +3,7 @@ package gregicadditions.jei;
 import com.google.common.collect.Lists;
 
 import gregtech.integration.jei.multiblock.MultiblockInfoRecipeWrapper;
+import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.IJeiHelpers;
 import mezz.jei.api.IModRegistry;
 import mezz.jei.api.gui.IDrawable;
@@ -14,9 +15,11 @@ import net.minecraft.client.resources.I18n;
 
 public class GAMultiblockInfoCategory implements IRecipeCategory<MultiblockInfoRecipeWrapper> {
 	private final IDrawable background;
+	private final IGuiHelper guiHelper;
 
 	public GAMultiblockInfoCategory(IJeiHelpers helpers) {
-		this.background = helpers.getGuiHelper().createBlankDrawable(176, 166);
+		this.guiHelper = helpers.getGuiHelper();
+		this.background = guiHelper.createBlankDrawable(176, 166);
 	}
 
 	public static void registerRecipes(IModRegistry registry) {
@@ -47,6 +50,6 @@ public class GAMultiblockInfoCategory implements IRecipeCategory<MultiblockInfoR
 
 	@Override
 	public void setRecipe(IRecipeLayout recipeLayout, MultiblockInfoRecipeWrapper recipeWrapper, IIngredients ingredients) {
-		recipeWrapper.setRecipeLayout((RecipeLayout) recipeLayout);
+		recipeWrapper.setRecipeLayout((RecipeLayout) recipeLayout, guiHelper);
 	}
 }


### PR DESCRIPTION
Updates the dependency version of GTCE to 1.12.0 and fixes the issue where multiblock previews in JEI would fail to display due to a change that happened in GTCE.

Closes #108 