### PR TITLE
Refactor the Processing Array

### DIFF
--- a/src/main/java/gregicadditions/GACapabilities.java
+++ b/src/main/java/gregicadditions/GACapabilities.java
@@ -1,0 +1,9 @@
+package gregicadditions;
+
+import gregtech.api.metatileentity.multiblock.MultiblockAbility;
+import net.minecraftforge.items.IItemHandlerModifiable;
+
+public class GACapabilities {
+
+    public static final MultiblockAbility<IItemHandlerModifiable> PA_MACHINE_CONTAINER = new MultiblockAbility<>();
+}

--- a/src/main/java/gregicadditions/GAConfig.java
+++ b/src/main/java/gregicadditions/GAConfig.java
@@ -172,6 +172,23 @@ public class GAConfig {
 		public boolean replaceUVwithMAXBat = false;
 	}
 
+	@Config.Comment("Config options of the Processing Array")
+	public static ProcessingArray processingArray = new ProcessingArray();
+
+	public static class ProcessingArray {
+
+		@Config.Comment("Number of machines the Processing Array can use at a time. Default: 16")
+		@Config.RangeInt(min = 1, max = 64)
+		public int processingArrayMachineLimit = 16;
+
+		@Config.Comment({"Blacklist of machines for the Processing Array.",
+						"Add the unlocalized Recipe Map name to blacklist the machine."})
+		public String[] machineBlackList = new String[0];
+
+	}
+
+
+
 	@Config.Comment("Config options of GTCE Bees features")
 	public static GTBees GTBees = new GTBees();
 

--- a/src/main/java/gregicadditions/GAEnums.java
+++ b/src/main/java/gregicadditions/GAEnums.java
@@ -36,20 +36,6 @@ public class GAEnums {
 
 	public static final Predicate<Material> dust = mat -> mat instanceof DustMaterial;
 	public static final Predicate<Material> ingot = mat -> mat instanceof IngotMaterial;
-	public static final HashMap<String, Integer> voltageMap = new HashMap<String, Integer>() {
-		{
-			put("lv", 32);
-			put("mv", 128);
-			put("hv", 512);
-			put("ev", 2048);
-			put("iv", 8192);
-			put("luv", 32768);
-			put("zpm", 131072);
-			put("uv", 524288);
-			put("max", Integer.MAX_VALUE);
-
-		}
-	};
 
 	private static Predicate<Material> pred(Predicate<Material> in) {
 		return mat -> in.test(mat);

--- a/src/main/java/gregicadditions/GAEnums.java
+++ b/src/main/java/gregicadditions/GAEnums.java
@@ -1,6 +1,5 @@
 package gregicadditions;
 
-import java.util.HashMap;
 import java.util.function.Predicate;
 
 import gregtech.api.GTValues;

--- a/src/main/java/gregicadditions/jei/ProcessingArrayInfo.java
+++ b/src/main/java/gregicadditions/jei/ProcessingArrayInfo.java
@@ -33,9 +33,10 @@ public class ProcessingArrayInfo extends MultiblockInfoPage {
 	public List<MultiblockShapeInfo> getMatchingShapes() {
 		MultiblockShapeInfo shapeInfo = MultiblockShapeInfo.builder()
 				.aisle("XIX", "XXX", "XXX")
-				.aisle("XXX", "S#E", "XXX")
+				.aisle("MXX", "S#E", "XXX")
 				.aisle("XOX", "XXX", "XXX")
 				.where('S', GATileEntities.PROCESSING_ARRAY, EnumFacing.WEST)
+				.where('M', GATileEntities.MACHINE_HOLDER, EnumFacing.WEST)
 				.where('X', MetaBlocks.METAL_CASING.getState(MetalCasingType.TUNGSTENSTEEL_ROBUST))
 				.where('#', Blocks.AIR.getDefaultState())
 				.where('I', MetaTileEntities.ITEM_IMPORT_BUS[GTValues.LV], EnumFacing.NORTH)

--- a/src/main/java/gregicadditions/jei/ProcessingArrayInfo.java
+++ b/src/main/java/gregicadditions/jei/ProcessingArrayInfo.java
@@ -36,7 +36,7 @@ public class ProcessingArrayInfo extends MultiblockInfoPage {
 				.aisle("MXX", "S#E", "XXX")
 				.aisle("XOX", "XXX", "XXX")
 				.where('S', GATileEntities.PROCESSING_ARRAY, EnumFacing.WEST)
-				.where('M', GATileEntities.MACHINE_HOLDER, EnumFacing.WEST)
+				.where('M', GATileEntities.MACHINE_ACCESS_INTERFACE, EnumFacing.WEST)
 				.where('X', MetaBlocks.METAL_CASING.getState(MetalCasingType.TUNGSTENSTEEL_ROBUST))
 				.where('#', Blocks.AIR.getDefaultState())
 				.where('I', MetaTileEntities.ITEM_IMPORT_BUS[GTValues.LV], EnumFacing.NORTH)

--- a/src/main/java/gregicadditions/jei/ProcessingArrayInfo.java
+++ b/src/main/java/gregicadditions/jei/ProcessingArrayInfo.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.google.common.collect.Lists;
 
+import gregicadditions.GAConfig;
 import gregicadditions.machines.GATileEntities;
 import gregtech.api.GTValues;
 import gregtech.api.metatileentity.multiblock.MultiblockControllerBase;
@@ -50,7 +51,7 @@ public class ProcessingArrayInfo extends MultiblockInfoPage {
 
 	@Override
 	public String[] getDescription() {
-		return new String[] { I18n.format("gregtech.multiblock.processing_array.description") };
+		return new String[] { I18n.format("gregtech.multiblock.processing_array.description", GAConfig.processingArray.processingArrayMachineLimit) };
 	}
 
 }

--- a/src/main/java/gregicadditions/machines/GATileEntities.java
+++ b/src/main/java/gregicadditions/machines/GATileEntities.java
@@ -427,7 +427,7 @@ public class GATileEntities {
 		}
 
 
-		MACHINE_ACCESS_INTERFACE = GregTechAPI.registerMetaTileEntity(2213, new MetaTileEntityMachineHolder(location("machine_holder")));
+		MACHINE_ACCESS_INTERFACE = GregTechAPI.registerMetaTileEntity(2213, new MetaTileEntityMachineHolder(location("machine_access_interface")));
 
 
 		// 2214 - 2221

--- a/src/main/java/gregicadditions/machines/GATileEntities.java
+++ b/src/main/java/gregicadditions/machines/GATileEntities.java
@@ -83,6 +83,8 @@ public class GATileEntities {
 	public static MetaTileEntityPump[] PUMP = new MetaTileEntityPump[8];
 	public static MetaTileEntityAirCollector[] AIR_COLLECTOR = new MetaTileEntityAirCollector[8];
 
+	public static MetaTileEntityMachineHolder MACHINE_HOLDER;
+
 	public static void init() {
 
 		if (GAConfig.GT5U.highTierClusterMills) {
@@ -423,6 +425,10 @@ public class GATileEntities {
 			TITANIUM_CRATE = GregTechAPI.registerMetaTileEntity(2211, new TileEntityCrate(location("crate.titanium"), Materials.Titanium, 108));
 			TUNGSTENSTEEL_CRATE = GregTechAPI.registerMetaTileEntity(2212, new TileEntityCrate(location("crate.tungstensteel"), Materials.TungstenSteel, 126));
 		}
+
+
+		MACHINE_HOLDER = GregTechAPI.registerMetaTileEntity(2213, new MetaTileEntityMachineHolder(location("machine_holder")));
+
 
 		// 2214 - 2221
 		IntStream.range(0, GAConfig.Misc.highTierBundler ? 8 : 4).forEach(tier -> {

--- a/src/main/java/gregicadditions/machines/GATileEntities.java
+++ b/src/main/java/gregicadditions/machines/GATileEntities.java
@@ -83,7 +83,7 @@ public class GATileEntities {
 	public static MetaTileEntityPump[] PUMP = new MetaTileEntityPump[8];
 	public static MetaTileEntityAirCollector[] AIR_COLLECTOR = new MetaTileEntityAirCollector[8];
 
-	public static MetaTileEntityMachineHolder MACHINE_HOLDER;
+	public static MetaTileEntityMachineHolder MACHINE_ACCESS_INTERFACE;
 
 	public static void init() {
 
@@ -427,7 +427,7 @@ public class GATileEntities {
 		}
 
 
-		MACHINE_HOLDER = GregTechAPI.registerMetaTileEntity(2213, new MetaTileEntityMachineHolder(location("machine_holder")));
+		MACHINE_ACCESS_INTERFACE = GregTechAPI.registerMetaTileEntity(2213, new MetaTileEntityMachineHolder(location("machine_holder")));
 
 
 		// 2214 - 2221

--- a/src/main/java/gregicadditions/machines/MetaTileEntityMachineHolder.java
+++ b/src/main/java/gregicadditions/machines/MetaTileEntityMachineHolder.java
@@ -19,13 +19,11 @@ import java.util.List;
 
 public class MetaTileEntityMachineHolder extends MetaTileEntityItemBus implements IMultiblockAbilityPart<IItemHandlerModifiable> {
 
-    private final MachineImportItemHandler machineStackHandler;
     protected IItemHandlerModifiable machineItemHandler;
 
     public MetaTileEntityMachineHolder(ResourceLocation metaTileEntityId) {
         super(metaTileEntityId, 0, false);
-        machineStackHandler = new MachineImportItemHandler();
-        machineItemHandler = createImportItemHandler();
+        machineItemHandler = new MachineImportItemHandler();
         initializeInventory();
     }
 
@@ -60,7 +58,7 @@ public class MetaTileEntityMachineHolder extends MetaTileEntityItemBus implement
 
     @Override
     protected IItemHandlerModifiable createImportItemHandler() {
-        return machineStackHandler;
+        return machineItemHandler;
     }
 
     private static class MachineImportItemHandler extends ItemStackHandler {

--- a/src/main/java/gregicadditions/machines/MetaTileEntityMachineHolder.java
+++ b/src/main/java/gregicadditions/machines/MetaTileEntityMachineHolder.java
@@ -61,6 +61,15 @@ public class MetaTileEntityMachineHolder extends MetaTileEntityItemBus implement
         return machineItemHandler;
     }
 
+    @Override
+    protected boolean openGUIOnRightClick() {
+        TileEntityProcessingArray controller = (TileEntityProcessingArray) getController();
+        if(controller != null && controller.getWorkable().isActive()) {
+            return false;
+        }
+        return true;
+    }
+
     private static class MachineImportItemHandler extends ItemStackHandler {
 
         @Nonnull

--- a/src/main/java/gregicadditions/machines/MetaTileEntityMachineHolder.java
+++ b/src/main/java/gregicadditions/machines/MetaTileEntityMachineHolder.java
@@ -1,0 +1,110 @@
+package gregicadditions.machines;
+
+import gregicadditions.GACapabilities;
+import gregtech.api.GregTechAPI;
+import gregtech.api.metatileentity.ITieredMetaTileEntity;
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
+import gregtech.api.metatileentity.multiblock.MultiblockAbility;
+import gregtech.common.metatileentities.electric.multiblockpart.MetaTileEntityItemBus;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.World;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.IItemHandlerModifiable;
+import net.minecraftforge.items.ItemStackHandler;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class MetaTileEntityMachineHolder extends MetaTileEntityItemBus implements IMultiblockAbilityPart<IItemHandlerModifiable> {
+
+    private final MachineImportItemHandler machineStackHandler;
+    protected IItemHandlerModifiable machineItemHandler;
+
+    public MetaTileEntityMachineHolder(ResourceLocation metaTileEntityId) {
+        super(metaTileEntityId, 0, false);
+        machineStackHandler = new MachineImportItemHandler();
+        machineItemHandler = createImportItemHandler();
+        initializeInventory();
+    }
+
+    @Override
+    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+        return new MetaTileEntityMachineHolder(metaTileEntityId);
+    }
+
+    @Override
+    public MultiblockAbility<IItemHandlerModifiable> getAbility() {
+        return GACapabilities.PA_MACHINE_CONTAINER;
+    }
+
+    @Override
+    public void registerAbilities(List<IItemHandlerModifiable> abilityList) {
+        //abilityList.add((IItemHandlerModifiable) GACapabilities.PA_MACHINE_CONTAINER);
+        abilityList.add(machineItemHandler);
+    }
+
+    protected IItemHandlerModifiable getMachineInventory() {
+        return machineItemHandler;
+    }
+
+    @Override
+    public IItemHandlerModifiable getImportItems() {
+        return machineItemHandler;
+    }
+
+    @Override
+    public IItemHandler getItemInventory() {
+        return machineItemHandler;
+    }
+
+
+
+    @Override
+    protected IItemHandlerModifiable createImportItemHandler() {
+        return machineStackHandler;
+    }
+
+
+
+    @Override
+    public void addInformation(ItemStack stack, @Nullable World player, List<String> tooltip, boolean advanced) {
+        super.addInformation(stack, player, tooltip, advanced);
+        tooltip.add(I18n.format("gtadditions.machine.machine_holder.tooltip"));
+    }
+
+    private static class MachineImportItemHandler extends ItemStackHandler {
+
+        @Nonnull
+        @Override
+        public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
+
+            if(!isItemValid(slot, stack)) {
+                return stack;
+            }
+
+            return super.insertItem(slot, stack, simulate);
+        }
+
+        @Override
+        public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
+
+            String unlocalizedName = stack.getItem().getUnlocalizedNameInefficiently(stack);
+
+            if(unlocalizedName.contains("gregtech.machine") || unlocalizedName.contains("gtadditions.machine")) {
+                MetaTileEntity mte = GregTechAPI.META_TILE_ENTITY_REGISTRY.getObjectById(stack.getItemDamage());
+                
+                if(mte != null && mte instanceof ITieredMetaTileEntity) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+    }
+}

--- a/src/main/java/gregicadditions/machines/MetaTileEntityMachineHolder.java
+++ b/src/main/java/gregicadditions/machines/MetaTileEntityMachineHolder.java
@@ -1,8 +1,6 @@
 package gregicadditions.machines;
 
 import gregicadditions.GACapabilities;
-import gregtech.api.block.machines.MachineItemBlock;
-import gregtech.api.metatileentity.ITieredMetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
@@ -82,13 +80,8 @@ public class MetaTileEntityMachineHolder extends MetaTileEntityItemBus implement
         @Override
         public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
 
-            if(stack.getItem() instanceof MachineItemBlock) {
-                MetaTileEntity mte = MachineItemBlock.getMetaTileEntity(stack);
+            return TileEntityProcessingArray.ProcessingArrayWorkable.findRecipeMapAndCheckValid(stack) != null;
 
-                return mte instanceof ITieredMetaTileEntity;
-            }
-
-            return false;
         }
 
     }

--- a/src/main/java/gregicadditions/machines/MetaTileEntityMachineHolder.java
+++ b/src/main/java/gregicadditions/machines/MetaTileEntityMachineHolder.java
@@ -1,7 +1,7 @@
 package gregicadditions.machines;
 
 import gregicadditions.GACapabilities;
-import gregtech.api.GregTechAPI;
+import gregtech.api.block.machines.MachineItemBlock;
 import gregtech.api.metatileentity.ITieredMetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
@@ -84,12 +84,10 @@ public class MetaTileEntityMachineHolder extends MetaTileEntityItemBus implement
 
             String unlocalizedName = stack.getItem().getUnlocalizedNameInefficiently(stack);
 
-            if(unlocalizedName.contains("gregtech.machine") || unlocalizedName.contains("gtadditions.machine")) {
-                MetaTileEntity mte = GregTechAPI.META_TILE_ENTITY_REGISTRY.getObjectById(stack.getItemDamage());
-                
-                if(mte != null && mte instanceof ITieredMetaTileEntity) {
-                    return true;
-                }
+            if(stack.getItem() instanceof MachineItemBlock) {
+                MetaTileEntity mte = MachineItemBlock.getMetaTileEntity(stack);
+
+                return mte instanceof ITieredMetaTileEntity;
             }
 
             return false;

--- a/src/main/java/gregicadditions/machines/MetaTileEntityMachineHolder.java
+++ b/src/main/java/gregicadditions/machines/MetaTileEntityMachineHolder.java
@@ -42,10 +42,6 @@ public class MetaTileEntityMachineHolder extends MetaTileEntityItemBus implement
         abilityList.add(machineItemHandler);
     }
 
-    protected IItemHandlerModifiable getMachineInventory() {
-        return machineItemHandler;
-    }
-
     @Override
     public IItemHandlerModifiable getImportItems() {
         return machineItemHandler;

--- a/src/main/java/gregicadditions/machines/MetaTileEntityMachineHolder.java
+++ b/src/main/java/gregicadditions/machines/MetaTileEntityMachineHolder.java
@@ -8,16 +8,13 @@ import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.multiblock.IMultiblockAbilityPart;
 import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.common.metatileentities.electric.multiblockpart.MetaTileEntityItemBus;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.world.World;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.List;
 
 public class MetaTileEntityMachineHolder extends MetaTileEntityItemBus implements IMultiblockAbilityPart<IItemHandlerModifiable> {
@@ -44,7 +41,6 @@ public class MetaTileEntityMachineHolder extends MetaTileEntityItemBus implement
 
     @Override
     public void registerAbilities(List<IItemHandlerModifiable> abilityList) {
-        //abilityList.add((IItemHandlerModifiable) GACapabilities.PA_MACHINE_CONTAINER);
         abilityList.add(machineItemHandler);
     }
 
@@ -62,19 +58,9 @@ public class MetaTileEntityMachineHolder extends MetaTileEntityItemBus implement
         return machineItemHandler;
     }
 
-
-
     @Override
     protected IItemHandlerModifiable createImportItemHandler() {
         return machineStackHandler;
-    }
-
-
-
-    @Override
-    public void addInformation(ItemStack stack, @Nullable World player, List<String> tooltip, boolean advanced) {
-        super.addInformation(stack, player, tooltip, advanced);
-        tooltip.add(I18n.format("gtadditions.machine.machine_holder.tooltip"));
     }
 
     private static class MachineImportItemHandler extends ItemStackHandler {

--- a/src/main/java/gregicadditions/machines/MetaTileEntityMachineHolder.java
+++ b/src/main/java/gregicadditions/machines/MetaTileEntityMachineHolder.java
@@ -82,8 +82,6 @@ public class MetaTileEntityMachineHolder extends MetaTileEntityItemBus implement
         @Override
         public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
 
-            String unlocalizedName = stack.getItem().getUnlocalizedNameInefficiently(stack);
-
             if(stack.getItem() instanceof MachineItemBlock) {
                 MetaTileEntity mte = MachineItemBlock.getMetaTileEntity(stack);
 

--- a/src/main/java/gregicadditions/machines/MetaTileEntityMachineHolder.java
+++ b/src/main/java/gregicadditions/machines/MetaTileEntityMachineHolder.java
@@ -55,16 +55,7 @@ public class MetaTileEntityMachineHolder extends MetaTileEntityItemBus implement
         return machineItemHandler;
     }
 
-    @Override
-    protected boolean openGUIOnRightClick() {
-        TileEntityProcessingArray controller = (TileEntityProcessingArray) getController();
-        if(controller != null && controller.getWorkable().isActive()) {
-            return false;
-        }
-        return true;
-    }
-
-    private static class MachineImportItemHandler extends ItemStackHandler {
+    private class MachineImportItemHandler extends ItemStackHandler {
 
         @Nonnull
         @Override
@@ -84,5 +75,16 @@ public class MetaTileEntityMachineHolder extends MetaTileEntityItemBus implement
 
         }
 
+        @Nonnull
+        @Override
+        public ItemStack extractItem(int slot, int amount, boolean simulate) {
+            TileEntityProcessingArray controller = (TileEntityProcessingArray) getController();
+
+            if(controller != null && controller.getWorkable().isActive()) {
+                return ItemStack.EMPTY;
+            }
+
+            return super.extractItem(slot, amount, simulate);
+        }
     }
 }

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -407,13 +407,17 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 
 		protected boolean didMachinesChange(ItemStack newMachineStack, ItemStack oldMachineStack) {
 
-			return newMachineStack != null && oldMachineStack != null && !ItemStack.areItemStacksEqual(oldMachineStack, newMachineStack);
+			if(newMachineStack == null || oldMachineStack == null) {
+				return true;
+			}
+
+			return !ItemStack.areItemStacksEqual(oldMachineStack, newMachineStack);
 		}
 
 		@Override
 		protected void trySearchNewRecipe() {
 			long maxVoltage = getMaxVoltage();
-			Recipe currentRecipe = null;
+			Recipe currentRecipe;
 			IItemHandlerModifiable importInventory = getInputInventory();
 			IMultipleTankHandler importFluids = getInputTank();
 
@@ -422,7 +426,7 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 			boolean dirty = checkRecipeInputsDirty(importInventory, importFluids);
 			if(dirty || forceRecipeRecheck) {
 				//Check if the machine that the PA is operating on has changed
-				if(didMachinesChange(newMachineStack, oldMachineStack)) {
+				if(newMachineStack == null || didMachinesChange(newMachineStack, oldMachineStack)) {
 					previousRecipe = null;
 					oldMachineStack = null;
 				}
@@ -435,10 +439,12 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 			else {
 				//If the previous recipe was null, or does not match the current recipe, search for a new recipe
 				currentRecipe = findRecipe(maxVoltage, importInventory, importFluids);
+				oldMachineStack = null;
 
 				//Update the previous recipe
 				if(currentRecipe != null) {
 					this.previousRecipe = currentRecipe;
+					newMachineStack = machineItemStack;
 				}
 
 				this.forceRecipeRecheck = false;
@@ -446,7 +452,7 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 
 			//Attempts to run the current recipe, if it is not null
 			if(currentRecipe != null && setupAndConsumeRecipeInputs(currentRecipe)) {
-				oldMachineStack = machineItemStack;
+				oldMachineStack = newMachineStack;
 				setupRecipe(currentRecipe);
 			}
 		}

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -179,7 +179,7 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 
 				//Skips empty slots in the input inventory, and slots that don't contain a recipe ingredient
 				//This means that the machine stack and non Consumed inputs are not added to the Ingredients list
-				if(wholeItemStack.isEmpty() || itemStackList.stream().anyMatch(stack -> areItemStacksEqual(stack, wholeItemStack))) {
+				if(wholeItemStack.isEmpty() || !itemStackList.stream().anyMatch(stack -> areItemStacksEqual(stack, wholeItemStack))) {
 					continue;
 				}
 
@@ -455,12 +455,13 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 			boolean dirty = checkRecipeInputsDirty(importInventory, importFluids);
 			if(dirty || forceRecipeRecheck) {
 				//Check if the machine that the PA is operating on has changed
-				if (!areItemStacksEqual(machineItemStack, findValidMachine(importInventory))) {
+				ItemStack newMachineStack = findValidMachine(importInventory);
+				if (newMachineStack == null || this.machineItemStack == null || !areItemStacksEqual(machineItemStack, newMachineStack)) {
 					previousRecipe = null;
 				}
-				this.forceRecipeRecheck = false;
 			}
-			else if(previousRecipe != null &&
+
+			if(previousRecipe != null &&
 					previousRecipe.matches(false, importInventory, importFluids)) {
 				currentRecipe = previousRecipe;
 			}
@@ -472,11 +473,14 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 				if(currentRecipe != null) {
 					this.previousRecipe = currentRecipe;
 				}
+
+				this.forceRecipeRecheck = false;
 			}
 
 			//Attempts to run the current recipe, if it is not null
-			if(currentRecipe != null && setupAndConsumeRecipeInputs(currentRecipe))
+			if(currentRecipe != null && setupAndConsumeRecipeInputs(currentRecipe)) {
 				setupRecipe(currentRecipe);
+			}
 		}
 
 		@Override

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -342,6 +342,9 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 			else if(trimmedName.equals("electric_furnace")) {
 				trimmedName = "furnace";
 			}
+			else if(trimmedName.equals("ore_washer")) {
+				trimmedName = "orewasher";
+			}
 
 			return trimmedName;
 		}

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -82,6 +82,10 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 		return new TileEntityProcessingArray(metaTileEntityId);
 	}
 
+	protected MultiblockRecipeLogic getWorkable() {
+		return recipeMapWorkable;
+	}
+
 	protected static class ProcessingArrayWorkable extends MultiblockRecipeLogic {
 		long voltageTier;
 		int numberOfMachines = 0;

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -168,6 +168,11 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 									IMultipleTankHandler fluidInputs) {
 
 
+			//Check if passed a null recipemap
+			if(recipeMap == null) {
+				return null;
+			}
+
 			MetaTileEntity mte = MachineItemBlock.getMetaTileEntity(machineItemStack);
 			if(mte == null) {
 				return null;

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -23,6 +23,7 @@ import gregtech.common.metatileentities.electric.MetaTileEntityMacerator;
 import net.minecraft.block.state.*;
 import net.minecraft.item.*;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.*;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentTranslation;
@@ -129,6 +130,18 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 	public void readFromNBT(NBTTagCompound data) {
 		super.readFromNBT(data);
 		isDistinct = data.getBoolean("Distinct");
+	}
+
+	@Override
+	public void writeInitialSyncData(PacketBuffer buf) {
+		super.writeInitialSyncData(buf);
+		buf.writeBoolean(isDistinct);
+	}
+
+	@Override
+	public void receiveInitialSyncData(PacketBuffer buf) {
+		super.receiveInitialSyncData(buf);
+		this.isDistinct = buf.readBoolean();
 	}
 
 	protected static class ProcessingArrayWorkable extends MultiblockRecipeLogic {

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -133,7 +133,6 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 												  .duration(recipe.getDuration());
 
 			copyChancedItemOutputs(newRecipe, recipe, minMultiplier);
-			//newRecipe.notConsumable(this.machineItemStack);
 			this.numberOfOperations = minMultiplier;
 			return newRecipe.build().getResult();
 		}
@@ -174,19 +173,13 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 				}
 			});
 
-			//Convert the ItemStack List to an Item List, for the ability to compare items while ignoring stack count
-			List<Item> itemList = new ArrayList<>();
-			for(ItemStack item : itemStackList) {
-				itemList.add(item.getItem());
-			}
-
 			//Iterate over the input inventory, to match items in the input inventory to the recipe items
 			for(int slot = 0; slot < inputs.getSlots(); slot++) {
 				ItemStack wholeItemStack = inputs.getStackInSlot(slot);
 
 				//Skips empty slots in the input inventory, and slots that don't contain a recipe ingredient
 				//This means that the machine stack and non Consumed inputs are not added to the Ingredients list
-				if(wholeItemStack.isEmpty() || !itemList.contains(wholeItemStack.getItem())) {
+				if(wholeItemStack.isEmpty() || itemStackList.stream().anyMatch(stack -> areItemStacksEqual(stack, wholeItemStack))) {
 					continue;
 				}
 

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -364,7 +364,7 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 		}
 
 		//Finds the Recipe Map of the passed Machine Stack and checks if it is a valid Recipe Map
-		protected RecipeMap<?> findRecipeMapAndCheckValid(ItemStack machineStack) {
+		public static RecipeMap<?> findRecipeMapAndCheckValid(ItemStack machineStack) {
 
 			if(machineStack == null || machineStack.isEmpty()) {
 				return null;
@@ -378,6 +378,10 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 			if(!findMachineInBlacklist(recipeMapName)) {
 
 				RecipeMap<?> rmap = RecipeMap.getByName(recipeMapName);
+
+				if(rmap == null) {
+					return null;
+				}
 
 				RecipeBuilder<?> rbuilder = rmap.recipeBuilder();
 
@@ -395,7 +399,7 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 			return null;
 		}
 
-		public String findRecipeMapName(String unlocalizedName) {
+		protected static String findRecipeMapName(String unlocalizedName) {
 
 			String trimmedName = unlocalizedName.substring(0, unlocalizedName.lastIndexOf("."));
 			trimmedName = trimmedName.substring(trimmedName.lastIndexOf(".") + 1);
@@ -416,7 +420,7 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 			return trimmedName;
 		}
 
-		public boolean findMachineInBlacklist(String unlocalizedName) {
+		protected static boolean findMachineInBlacklist(String unlocalizedName) {
 
 			String[] blacklist = GAConfig.processingArray.machineBlackList;
 

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -105,7 +105,7 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 				return null;
 			}
 
-			//Find the voltage tier of the machine. The machine input bus can only accept ITieredMTEs, so this cast is safe
+			//Find the voltage tier of the machine.
 			this.voltageTier = GTValues.V[((ITieredMetaTileEntity) mte).getTier()];
 			//Find the number of machines
 			this.numberOfMachines = Math.min(GAConfig.processingArray.processingArrayMachineLimit, machineItemStack.getCount());
@@ -126,7 +126,7 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 			if(recipe == null)
 				return null;
 
-			Set<ItemStack> ingredientStacks = findIngredients(inputs, recipe);
+			Set<ItemStack> ingredientStacks = findIngredients(inputs);
 			Map<String, Integer> fluidStacks = findFluid(fluidInputs);
 
 			int itemMultiplier = getMinRatioItem(ingredientStacks, recipe, this.numberOfMachines);
@@ -177,12 +177,12 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 			}
 		}
 
-		protected static Set<ItemStack> findIngredients(IItemHandlerModifiable inputs, Recipe recipe) {
+		protected static Set<ItemStack> findIngredients(IItemHandlerModifiable inputs) {
 			Set<ItemStack> countIngredients = new HashSet<>();
 			for(int slot = 0; slot < inputs.getSlots(); slot++) {
 				ItemStack wholeItemStack = inputs.getStackInSlot(slot);
 
-				// skip empty slots
+				//Skip empty slots
 				if(wholeItemStack.isEmpty())
 					continue;
 
@@ -314,11 +314,8 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 						rmap.recipeBuilder() instanceof UniversalDistillationRecipeBuilder)) {
 
 					return rmap;
-
 				}
-
 			}
-
 			return null;
 		}
 

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -107,6 +107,9 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 		withHoverTextTranslate(button, "gtadditions.multiblock.processing_array.distinct.info");
 		buttonText.appendSibling(button);
 		textList.add(buttonText);
+		if(this.recipeMapWorkable.isActive()) {
+			textList.add(new TextComponentTranslation("gtadditions.multiblock.processing_array.locked"));
+		}
 	}
 
 	@Override

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -302,6 +302,10 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 		//Finds the Recipe Map of the passed Machine Stack and checks if it is a valid Recipe Map
 		protected RecipeMap findRecipeMapAndCheckValid(ItemStack machineStack) {
 
+			if(machineStack == null || machineStack.isEmpty()) {
+				return null;
+			}
+
 			String unlocalizedName = machineStack.getItem().getUnlocalizedNameInefficiently(machineStack);
 			String recipeMapName = findRecipeMapName(unlocalizedName);
 
@@ -352,18 +356,10 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 		public ItemStack findMachineStack() {
 			RecipeMapMultiblockController controller = (RecipeMapMultiblockController) this.metaTileEntity;
 
-			//The Processing Array is limited to 1 Machine Holder per multiblock, and only has 1 slot
+			//The Processing Array is limited to 1 Machine Interface per multiblock, and only has 1 slot
 			ItemStack machine = controller.getAbilities(GACapabilities.PA_MACHINE_CONTAINER).get(0).getStackInSlot(0);
 
-			if(machine.isEmpty()) {
-				return null;
-			}
-			else if(findRecipeMapAndCheckValid(machine) != null) {
-				return machine;
-			}
-			else {
-				return null;
-			}
+			return findRecipeMapAndCheckValid(machine) == null ? null : machine;
 		}
 
 		@Override

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -160,6 +160,9 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 									IItemHandlerModifiable inputs,
 									IMultipleTankHandler fluidInputs) {
 
+			//Update the machine stack and recipe map
+			findMachineStack();
+
 			return findRecipe(maxVoltage, inputs, fluidInputs, machineItemStack, recipeMap);
 
 		}
@@ -525,7 +528,7 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 			}
 			else {
 				//If the previous recipe was null, or does not match the current recipe, search for a new recipe
-				currentRecipe = findRecipe(maxVoltage, importInventory, importFluids);
+				currentRecipe = findRecipe(maxVoltage, importInventory, importFluids, machineItemStack, recipeMap);
 				oldMachineStack = null;
 
 				//Update the previous recipe
@@ -586,7 +589,7 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 				boolean dirty = checkRecipeInputsDirty(bus, importFluids, i);
 				if (dirty || forceRecipeRecheck) {
 					this.forceRecipeRecheck = false;
-					currentRecipe = findRecipe(maxVoltage, bus, importFluids);
+					currentRecipe = findRecipe(maxVoltage, bus, importFluids, machineItemStack, recipeMap);
 					if (currentRecipe != null) {
 						this.previousRecipe = currentRecipe;
 					}

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -405,13 +405,13 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 				recipe.matches(true, importInventory, importFluids);
 		}
 
-		protected boolean didMachinesChange(ItemStack newMachineStack, ItemStack oldMachineStack) {
+		protected boolean didMachinesChange(ItemStack newMachineStack) {
 
-			if(newMachineStack == null || oldMachineStack == null) {
+			if(newMachineStack == null || this.oldMachineStack == null) {
 				return true;
 			}
 
-			return !ItemStack.areItemStacksEqual(oldMachineStack, newMachineStack);
+			return !ItemStack.areItemStacksEqual(this.oldMachineStack, newMachineStack);
 		}
 
 		@Override
@@ -426,7 +426,7 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 			boolean dirty = checkRecipeInputsDirty(importInventory, importFluids);
 			if(dirty || forceRecipeRecheck) {
 				//Check if the machine that the PA is operating on has changed
-				if(newMachineStack == null || didMachinesChange(newMachineStack, oldMachineStack)) {
+				if(didMachinesChange(newMachineStack)) {
 					previousRecipe = null;
 					oldMachineStack = null;
 				}

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -431,11 +431,8 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 			ItemStack machine = controller.getAbilities(GACapabilities.PA_MACHINE_CONTAINER).get(0).getStackInSlot(0);
 
 			RecipeMap<?> rmap = findRecipeMapAndCheckValid(machine);
-			if(rmap == null) {
-				return null;
-			}
 
-			return new Tuple<ItemStack, RecipeMap<?>>(machine, rmap);
+			return (rmap == null) ? null : new Tuple<>(machine, rmap);
 		}
 
 		@Override
@@ -529,7 +526,6 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 				//Update the previous recipe
 				if(currentRecipe != null) {
 					this.previousRecipe = currentRecipe;
-					newMachineStack = machineItemStack;
 				}
 
 				this.forceRecipeRecheck = false;
@@ -595,7 +591,6 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 					this.forceRecipeRecheck = false;
 					currentRecipe = findRecipe(maxVoltage, bus, importFluids);
 					if (currentRecipe != null) {
-						newMachineStack = machineItemStack;
 						this.previousRecipe = currentRecipe;
 					}
 				}

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -100,6 +100,9 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 		withHoverTextTranslate(button, "gtadditions.multiblock.processing_array.distinct.info");
 		buttonText.appendSibling(button);
 		textList.add(buttonText);
+		textList.add(new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct2", isDistinctInputBusMode ?
+				new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct.yes") :
+				new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct.no")));
 		if(this.recipeMapWorkable.isActive()) {
 			textList.add(new TextComponentTranslation("gtadditions.multiblock.processing_array.locked"));
 		}

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -445,6 +445,7 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 			this.recipeEUt = resultOverclock[0] * this.numberOfOperations;
 			this.fluidOutputs = GTUtility.copyFluidList(recipe.getFluidOutputs());
 			int tier = getMachineTierForRecipe(recipe);
+			setActive(true);
 			this.itemOutputs = GTUtility.copyStackList(recipe.getResultItemOutputs(getOutputInventory().getSlots(),
 																				   random,
 																				   tier));

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -351,30 +351,19 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 
 		public ItemStack findMachineStack() {
 			RecipeMapMultiblockController controller = (RecipeMapMultiblockController) this.metaTileEntity;
-			List<IMultiblockPart> parts = controller.getMultiblockParts();
-			//This should never be null, since it is required for the structure to form.
-			MetaTileEntityMachineHolder machineHolder = null;
-			for (IMultiblockPart part : parts) {
-				if (part instanceof MetaTileEntityMachineHolder) {
-					machineHolder = (MetaTileEntityMachineHolder) part;
-					break;
-				}
-			}
 
-			if(machineHolder == null) {
+			//The Processing Array is limited to 1 Machine Holder per multiblock, and only has 1 slot
+			ItemStack machine = controller.getAbilities(GACapabilities.PA_MACHINE_CONTAINER).get(0).getStackInSlot(0);
+
+			if(machine.isEmpty()) {
 				return null;
 			}
-
-			IItemHandlerModifiable machineInventory = machineHolder.getMachineInventory();
-
-			//The machine holder block is always only 1 slot
-			ItemStack machine =  machineInventory.getStackInSlot(0);
-
-			if(findRecipeMapAndCheckValid(machine) != null) {
+			else if(findRecipeMapAndCheckValid(machine) != null) {
 				return machine;
 			}
-
-			return null;
+			else {
+				return null;
+			}
 		}
 
 		@Override

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -49,15 +49,16 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 		return FactoryBlockPattern.start()
 								  .aisle("XXX", "XXX", "XXX")
 								  .aisle("XXX", "X#X", "XXX")
-								  .aisle("XMX", "XSX", "XXX")
+								  .aisle("XXX", "XSX", "XXX")
 								  .setAmountAtLeast('L', 12)
-								  .setAmountAtMost('M', 1)
+								  .setAmountLimit('M', 1, 1)
 								  .where('M', machineHolderPredicate())
 								  .where('L', statePredicate(getCasingState()))
 								  .where('S', selfPredicate())
 								  .where('X',
 										 statePredicate(getCasingState())
-											 .or(abilityPartPredicate(ALLOWED_ABILITIES)))
+											 .or(abilityPartPredicate(ALLOWED_ABILITIES))
+								    		 .or(machineHolderPredicate()))
 								  .where('#', isAirPredicate()).build();
 	}
 

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -139,6 +139,12 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 		this.isDistinctInputBusMode = buf.readBoolean();
 	}
 
+	@Override
+	public void invalidateStructure() {
+		super.invalidateStructure();
+		((ProcessingArrayWorkable) this.recipeMapWorkable).invalidate();
+	}
+
 	protected static class ProcessingArrayWorkable extends MultiblockRecipeLogic {
 		long voltageTier;
 		int numberOfMachines = 0;
@@ -371,6 +377,10 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 			recipe.getFluidOutputs().forEach(fluidStack ->
 				outputFluids.add(copyFluidStackWithAmount(fluidStack,
 														  fluidStack.amount * numberOfOperations)));
+		}
+
+		public void invalidate() {
+			this.lastRecipeIndex = 0;
 		}
 
 		//Finds the Recipe Map of the passed Machine Stack and checks if it is a valid Recipe Map

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -474,11 +474,14 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 				recipe.matches(true, importInventory, importFluids);
 		}
 
+		/**
+		 * Will check if the previous machine stack and the current machine stack are different
+		 * @param newMachineStack - The current machine stack
+		 * @return - true if the machine stacks are not equal, false if they are equal
+		 */
 		protected boolean didMachinesChange(ItemStack newMachineStack) {
-
-			if(newMachineStack == null || this.oldMachineStack == null) {
-				return true;
-			}
+			if(newMachineStack == null || this.oldMachineStack == null)
+				return newMachineStack != this.oldMachineStack;
 
 			return !ItemStack.areItemStacksEqual(this.oldMachineStack, newMachineStack);
 		}

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -545,11 +545,13 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 				currentRecipe = previousRecipe;
 				if(setupAndConsumeRecipeInputs(currentRecipe, lastRecipeIndex)) {
 					setupRecipe(currentRecipe);
+					oldMachineStack = newMachineStack;
 					return;
 				}
 			}
 
 			//If the machine stack changed, or the previous recipe is null, check for a new recipe
+			oldMachineStack = null;
 			for (int i = 0; i < importInventory.size(); i++) {
 				IItemHandlerModifiable bus = importInventory.get(i);
 				boolean dirty = checkRecipeInputsDirty(bus, importFluids, i);
@@ -557,12 +559,14 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 					this.forceRecipeRecheck = false;
 					currentRecipe = findRecipe(maxVoltage, bus, importFluids);
 					if (currentRecipe != null) {
+						newMachineStack = machineItemStack;
 						this.previousRecipe = currentRecipe;
 					}
 				}
 				if(currentRecipe != null && setupAndConsumeRecipeInputs(currentRecipe, i)) {
 					lastRecipeIndex = i;
 					setupRecipe(currentRecipe);
+					oldMachineStack = newMachineStack;
 					break;
 				}
 			}

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -456,7 +456,6 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 			this.recipeEUt = resultOverclock[0] * this.numberOfOperations;
 			this.fluidOutputs = GTUtility.copyFluidList(recipe.getFluidOutputs());
 			int tier = getMachineTierForRecipe(recipe);
-			setActive(true);
 			this.itemOutputs = GTUtility.copyStackList(recipe.getResultItemOutputs(getOutputInventory().getSlots(),
 																				   random,
 																				   tier));

--- a/src/main/java/gregicadditions/recipes/MachineCraftingRecipes.java
+++ b/src/main/java/gregicadditions/recipes/MachineCraftingRecipes.java
@@ -361,7 +361,7 @@ public class MachineCraftingRecipes {
 		registerMachineRecipe(GATileEntities.REPLICATOR, "EFE", "CMC", "EQE", 'M', HULL, 'Q', CABLE_QUAD, 'C', BETTER_CIRCUIT, 'F', FIELD_GENERATOR, 'E', EMITTER);
 		if (GAConfig.Misc.highTierCollector) registerMachineRecipe(GATileEntities.AIR_COLLECTOR, "WFW", "PHP", "WCW", 'W', Blocks.IRON_BARS, 'F', MetaItems.ITEM_FILTER, 'P', PUMP, 'H', HULL, 'C', CIRCUIT);
 
-		ModHandler.addShapedRecipe("machine_access_interface", GATileEntities.MACHINE_ACCESS_INTERFACE.getStackForm(), " C ", " H ", "   ", 'C', new UnificationEntry(OrePrefix.valueOf("circuit"), Tier.Elite), 'H', MetaTileEntities.ITEM_IMPORT_BUS[GTValues.ULV].getStackForm());
+		ModHandler.addShapedRecipe("machine_access_interface", GATileEntities.MACHINE_ACCESS_INTERFACE.getStackForm(), "C", "H", 'C', new UnificationEntry(OrePrefix.valueOf("circuit"), Tier.Elite), 'H', MetaTileEntities.ITEM_IMPORT_BUS[GTValues.ULV].getStackForm());
 
 		registerMachineRecipe(GATileEntities.BUNDLER,
 							  "BCB",

--- a/src/main/java/gregicadditions/recipes/MachineCraftingRecipes.java
+++ b/src/main/java/gregicadditions/recipes/MachineCraftingRecipes.java
@@ -361,7 +361,7 @@ public class MachineCraftingRecipes {
 		registerMachineRecipe(GATileEntities.REPLICATOR, "EFE", "CMC", "EQE", 'M', HULL, 'Q', CABLE_QUAD, 'C', BETTER_CIRCUIT, 'F', FIELD_GENERATOR, 'E', EMITTER);
 		if (GAConfig.Misc.highTierCollector) registerMachineRecipe(GATileEntities.AIR_COLLECTOR, "WFW", "PHP", "WCW", 'W', Blocks.IRON_BARS, 'F', MetaItems.ITEM_FILTER, 'P', PUMP, 'H', HULL, 'C', CIRCUIT);
 
-		ModHandler.addShapedRecipe("machine_holder", GATileEntities.MACHINE_HOLDER.getStackForm(), " C ", " H ", "   ", 'C', new UnificationEntry(OrePrefix.valueOf("circuit"), Tier.Elite), 'H', MetaTileEntities.ITEM_IMPORT_BUS[GTValues.ULV].getStackForm());
+		ModHandler.addShapedRecipe("machine_access_interface", GATileEntities.MACHINE_ACCESS_INTERFACE.getStackForm(), " C ", " H ", "   ", 'C', new UnificationEntry(OrePrefix.valueOf("circuit"), Tier.Elite), 'H', MetaTileEntities.ITEM_IMPORT_BUS[GTValues.ULV].getStackForm());
 
 		registerMachineRecipe(GATileEntities.BUNDLER,
 							  "BCB",

--- a/src/main/java/gregicadditions/recipes/MachineCraftingRecipes.java
+++ b/src/main/java/gregicadditions/recipes/MachineCraftingRecipes.java
@@ -360,6 +360,9 @@ public class MachineCraftingRecipes {
 		registerMachineRecipe(GATileEntities.MASS_FAB, "CFC", "QMQ", "CFC", 'M', HULL, 'Q', CABLE_QUAD, 'C', BETTER_CIRCUIT, 'F', FIELD_GENERATOR);
 		registerMachineRecipe(GATileEntities.REPLICATOR, "EFE", "CMC", "EQE", 'M', HULL, 'Q', CABLE_QUAD, 'C', BETTER_CIRCUIT, 'F', FIELD_GENERATOR, 'E', EMITTER);
 		if (GAConfig.Misc.highTierCollector) registerMachineRecipe(GATileEntities.AIR_COLLECTOR, "WFW", "PHP", "WCW", 'W', Blocks.IRON_BARS, 'F', MetaItems.ITEM_FILTER, 'P', PUMP, 'H', HULL, 'C', CIRCUIT);
+
+		ModHandler.addShapedRecipe("machine_holder", GATileEntities.MACHINE_HOLDER.getStackForm(), " C ", " H ", "   ", 'C', new UnificationEntry(OrePrefix.valueOf("circuit"), Tier.Elite), 'H', MetaTileEntities.ITEM_IMPORT_BUS[GTValues.ULV].getStackForm());
+
 		registerMachineRecipe(GATileEntities.BUNDLER,
 							  "BCB",
 							  "RMV",

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -489,7 +489,7 @@ gregtech.multiblock.fusion_reactor.heat=Heat: %d
 # Processing Array
 recipemap.processing_array.name=Processing Array
 gtadditions.machine.processing_array.name=Processing Array
-gregtech.multiblock.processing_array.description=The Processing Array combines up to 16 single block machines in a single multiblock, effectively easing automation.
+gregtech.multiblock.processing_array.description=The Processing Array combines up to %d single block machine(s) in a single multiblock, effectively easing automation.
 
 # Assembly Line
 recipemap.assembly_line.name=Assembly Line

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -493,6 +493,10 @@ gregtech.multiblock.fusion_reactor.heat=Heat: %d
 recipemap.processing_array.name=Processing Array
 gtadditions.machine.processing_array.name=Processing Array
 gregtech.multiblock.processing_array.description=The Processing Array combines up to %d single block machine(s) in a single multiblock, effectively easing automation.
+gtadditions.multiblock.processing_array.distinct=Distinct Buses:
+gtadditions.multiblock.processing_array.distinct.yes=§aYes
+gtadditions.multiblock.processing_array.distinct.no=§cNo
+gtadditions.multiblock.universal.processing_array.info=If enabled, each bus will be treated as fully distinct from eachother for recipe lookup. Useful for example for Extruder Shapes, Laser Lenses, etc..
 
 # Assembly Line
 recipemap.assembly_line.name=Assembly Line

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -496,7 +496,7 @@ gregtech.multiblock.processing_array.description=The Processing Array combines u
 gtadditions.multiblock.processing_array.distinct=Distinct Buses:
 gtadditions.multiblock.processing_array.distinct.yes=§aYes
 gtadditions.multiblock.processing_array.distinct.no=§cNo
-gtadditions.multiblock.universal.processing_array.info=If enabled, each bus will be treated as fully distinct from eachother for recipe lookup. Useful for example for Extruder Shapes, Laser Lenses, etc..
+gtadditions.multiblock.processing_array.distinct.info=If enabled, each bus will be treated as fully distinct from each other for recipe lookup. Useful for example for Extruder Shapes, Laser Lenses, etc..
 
 # Assembly Line
 recipemap.assembly_line.name=Assembly Line

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -497,6 +497,7 @@ gtadditions.multiblock.processing_array.distinct=Distinct Buses:
 gtadditions.multiblock.processing_array.distinct.yes=§aYes
 gtadditions.multiblock.processing_array.distinct.no=§cNo
 gtadditions.multiblock.processing_array.distinct.info=If enabled, each bus will be treated as fully distinct from each other for recipe lookup. Useful for example for Extruder Shapes, Laser Lenses, etc..
+gtadditions.multiblock.processing_array.locked=§cMachine Hatch Locked
 
 # Assembly Line
 recipemap.assembly_line.name=Assembly Line

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -496,7 +496,7 @@ gregtech.multiblock.processing_array.description=The Processing Array combines u
 gtadditions.multiblock.processing_array.distinct=Distinct Buses:
 gtadditions.multiblock.processing_array.distinct.yes=§aYes
 gtadditions.multiblock.processing_array.distinct.no=§cNo
-gtadditions.multiblock.processing_array.distinct.info=If enabled, each bus will be treated as fully distinct from each other for recipe lookup. Useful for example for Extruder Shapes, Laser Lenses, etc..
+gtadditions.multiblock.processing_array.distinct.info=If enabled, each bus will be treated as fully distinct from each other for recipe lookup. Useful for things like Extruder Shapes, Laser Lenses, etc..
 gtadditions.multiblock.processing_array.locked=§cMachine Hatch Locked
 
 # Assembly Line

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -494,6 +494,7 @@ recipemap.processing_array.name=Processing Array
 gtadditions.machine.processing_array.name=Processing Array
 gregtech.multiblock.processing_array.description=The Processing Array combines up to %d single block machine(s) in a single multiblock, effectively easing automation.
 gtadditions.multiblock.processing_array.distinct=Distinct Buses:
+gtadditions.multiblock.processing_array.distinct2=[Click %s to Toggle]
 gtadditions.multiblock.processing_array.distinct.yes=§aYes
 gtadditions.multiblock.processing_array.distinct.no=§cNo
 gtadditions.multiblock.processing_array.distinct.info=If enabled, each bus will be treated as fully distinct from each other for recipe lookup. Useful for things like Extruder Shapes, Laser Lenses, etc..

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -461,6 +461,7 @@ gtadditions.machine.bundler.uv.tooltip=Lapinotron 9000
 
 # Machine Access Interface
 gtadditions.machine.machine_holder.name=Machine Access Interface
+gtadditions.machine.machine_holder.tooltip=Specialized Access Bus required for the Processing Array to hold the machines the Processing Array is operating on. Only holds valid machines.
 
 # Pump
 gtadditions.machine.pump.iv.name=Advanced Pump IV

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -460,8 +460,8 @@ gtadditions.machine.bundler.uv.name=Elite Bundler III
 gtadditions.machine.bundler.uv.tooltip=Lapinotron 9000
 
 # Machine Access Interface
-gtadditions.machine.machine_holder.name=Machine Access Interface
-gtadditions.machine.machine_holder.tooltip=Specialized Access Bus required for the Processing Array to hold the machines the Processing Array is operating on. Only holds valid machines.
+gtadditions.machine.machine_access_interface.name=Machine Access Interface
+gtadditions.machine.machine_access_interface.tooltip=Specialized Access Bus required for the Processing Array to hold the machines the Processing Array is operating on. Only holds valid machines.
 
 # Pump
 gtadditions.machine.pump.iv.name=Advanced Pump IV

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -459,6 +459,8 @@ gtadditions.machine.bundler.zpm.tooltip=Lapinotron 6000
 gtadditions.machine.bundler.uv.name=Elite Bundler III
 gtadditions.machine.bundler.uv.tooltip=Lapinotron 9000
 
+# Machine Access Interface
+gtadditions.machine.machine_holder.name=Machine Access Interface
 
 # Pump
 gtadditions.machine.pump.iv.name=Advanced Pump IV

--- a/src/main/resources/assets/gtadditions/lang/ru_ru.lang
+++ b/src/main/resources/assets/gtadditions/lang/ru_ru.lang
@@ -488,7 +488,7 @@ gregtech.multiblock.fusion_reactor.heat=Теплота: %d
 # Processing Array
 recipemap.processing_array.name=Processing Array
 gtadditions.machine.processing_array.name=Processing Array
-gregtech.multiblock.processing_array.description=The Processing Array combines up to 16 single block machines in a single multiblock, effectively easing automation.
+gregtech.multiblock.processing_array.description=The Processing Array combines up to %d single block machine(s) in a single multiblock, effectively easing automation.
 
 # Assembly Line
 recipemap.assembly_line.name=Assembly Line

--- a/src/main/resources/assets/gtadditions/lang/ru_ru.lang
+++ b/src/main/resources/assets/gtadditions/lang/ru_ru.lang
@@ -497,6 +497,7 @@ gtadditions.multiblock.processing_array.distinct=Distinct Buses:
 gtadditions.multiblock.processing_array.distinct.yes=§aYes
 gtadditions.multiblock.processing_array.distinct.no=§cNo
 gtadditions.multiblock.processing_array.distinct.info=If enabled, each bus will be treated as fully distinct from each other for recipe lookup. Useful for example for Extruder Shapes, Laser Lenses, etc..
+gtadditions.multiblock.processing_array.locked=§cMachine Hatch Locked
 
 # Assembly Line
 recipemap.assembly_line.name=Assembly Line

--- a/src/main/resources/assets/gtadditions/lang/ru_ru.lang
+++ b/src/main/resources/assets/gtadditions/lang/ru_ru.lang
@@ -496,7 +496,7 @@ gregtech.multiblock.processing_array.description=The Processing Array combines u
 gtadditions.multiblock.processing_array.distinct=Distinct Buses:
 gtadditions.multiblock.processing_array.distinct.yes=§aYes
 gtadditions.multiblock.processing_array.distinct.no=§cNo
-gtadditions.multiblock.processing_array.distinct.info=If enabled, each bus will be treated as fully distinct from each other for recipe lookup. Useful for example for Extruder Shapes, Laser Lenses, etc..
+gtadditions.multiblock.processing_array.distinct.info=If enabled, each bus will be treated as fully distinct from each other for recipe lookup. Useful for things like Extruder Shapes, Laser Lenses, etc..
 gtadditions.multiblock.processing_array.locked=§cMachine Hatch Locked
 
 # Assembly Line

--- a/src/main/resources/assets/gtadditions/lang/ru_ru.lang
+++ b/src/main/resources/assets/gtadditions/lang/ru_ru.lang
@@ -494,6 +494,7 @@ recipemap.processing_array.name=Processing Array
 gtadditions.machine.processing_array.name=Processing Array
 gregtech.multiblock.processing_array.description=The Processing Array combines up to %d single block machine(s) in a single multiblock, effectively easing automation.
 gtadditions.multiblock.processing_array.distinct=Distinct Buses:
+gtadditions.multiblock.processing_array.distinct2=[Click %s to Toggle]
 gtadditions.multiblock.processing_array.distinct.yes=§aYes
 gtadditions.multiblock.processing_array.distinct.no=§cNo
 gtadditions.multiblock.processing_array.distinct.info=If enabled, each bus will be treated as fully distinct from each other for recipe lookup. Useful for things like Extruder Shapes, Laser Lenses, etc..

--- a/src/main/resources/assets/gtadditions/lang/ru_ru.lang
+++ b/src/main/resources/assets/gtadditions/lang/ru_ru.lang
@@ -459,6 +459,10 @@ gtadditions.machine.bundler.zpm.tooltip=Lapinotron 6000
 gtadditions.machine.bundler.uv.name=Elite Bundler III
 gtadditions.machine.bundler.uv.tooltip=Lapinotron 9000
 
+# Machine Access Interface
+gtadditions.machine.machine_access_interface.name=Machine Access Interface
+gtadditions.machine.machine_access_interface.tooltip=Specialized Access Bus required for the Processing Array to hold the machines the Processing Array is operating on. Only holds valid machines.
+
 # Pump
 gtadditions.machine.pump.iv.name=Улучшенный Pump IV
 gtadditions.machine.pump.luv.name=Улучшенный Pump V
@@ -489,6 +493,10 @@ gregtech.multiblock.fusion_reactor.heat=Теплота: %d
 recipemap.processing_array.name=Processing Array
 gtadditions.machine.processing_array.name=Processing Array
 gregtech.multiblock.processing_array.description=The Processing Array combines up to %d single block machine(s) in a single multiblock, effectively easing automation.
+gtadditions.multiblock.processing_array.distinct=Distinct Buses:
+gtadditions.multiblock.processing_array.distinct.yes=§aYes
+gtadditions.multiblock.processing_array.distinct.no=§cNo
+gtadditions.multiblock.processing_array.distinct.info=If enabled, each bus will be treated as fully distinct from each other for recipe lookup. Useful for example for Extruder Shapes, Laser Lenses, etc..
 
 # Assembly Line
 recipemap.assembly_line.name=Assembly Line

--- a/src/main/resources/assets/gtadditions/lang/zh_cn.lang
+++ b/src/main/resources/assets/gtadditions/lang/zh_cn.lang
@@ -459,6 +459,9 @@ gtadditions.machine.bundler.zpm.tooltip=Lapinotron 6000
 gtadditions.machine.bundler.uv.name=Elite Bundler III
 gtadditions.machine.bundler.uv.tooltip=Lapinotron 9000
 
+# Machine Access Interface
+gtadditions.machine.machine_access_interface.name=Machine Access Interface
+gtadditions.machine.machine_access_interface.tooltip=Specialized Access Bus required for the Processing Array to hold the machines the Processing Array is operating on. Only holds valid machines.
 
 # Pump
 gtadditions.machine.pump.iv.name=进阶泵 IV
@@ -489,7 +492,11 @@ gregtech.multiblock.fusion_reactor.heat=热力: %d
 # Processing Array
 recipemap.processing_array.name=Processing Array
 gtadditions.machine.processing_array.name=Processing Array
-gregtech.multiblock.processing_array.description=The Processing Array combines up to 16 single block machines in a single multiblock, effectively easing automation.
+gregtech.multiblock.processing_array.description=The Processing Array combines up to %d single block machine(s) in a single multiblock, effectively easing automation.
+gtadditions.multiblock.processing_array.distinct=Distinct Buses:
+gtadditions.multiblock.processing_array.distinct.yes=§aYes
+gtadditions.multiblock.processing_array.distinct.no=§cNo
+gtadditions.multiblock.processing_array.distinct.info=If enabled, each bus will be treated as fully distinct from each other for recipe lookup. Useful for example for Extruder Shapes, Laser Lenses, etc..
 
 # Assembly Line
 recipemap.assembly_line.name=装配线

--- a/src/main/resources/assets/gtadditions/lang/zh_cn.lang
+++ b/src/main/resources/assets/gtadditions/lang/zh_cn.lang
@@ -497,6 +497,7 @@ gtadditions.multiblock.processing_array.distinct=Distinct Buses:
 gtadditions.multiblock.processing_array.distinct.yes=§aYes
 gtadditions.multiblock.processing_array.distinct.no=§cNo
 gtadditions.multiblock.processing_array.distinct.info=If enabled, each bus will be treated as fully distinct from each other for recipe lookup. Useful for example for Extruder Shapes, Laser Lenses, etc..
+gtadditions.multiblock.processing_array.locked=§cMachine Hatch Locked
 
 # Assembly Line
 recipemap.assembly_line.name=装配线

--- a/src/main/resources/assets/gtadditions/lang/zh_cn.lang
+++ b/src/main/resources/assets/gtadditions/lang/zh_cn.lang
@@ -496,7 +496,7 @@ gregtech.multiblock.processing_array.description=The Processing Array combines u
 gtadditions.multiblock.processing_array.distinct=Distinct Buses:
 gtadditions.multiblock.processing_array.distinct.yes=§aYes
 gtadditions.multiblock.processing_array.distinct.no=§cNo
-gtadditions.multiblock.processing_array.distinct.info=If enabled, each bus will be treated as fully distinct from each other for recipe lookup. Useful for example for Extruder Shapes, Laser Lenses, etc..
+gtadditions.multiblock.processing_array.distinct.info=If enabled, each bus will be treated as fully distinct from each other for recipe lookup. Useful for things like Extruder Shapes, Laser Lenses, etc..
 gtadditions.multiblock.processing_array.locked=§cMachine Hatch Locked
 
 # Assembly Line

--- a/src/main/resources/assets/gtadditions/lang/zh_cn.lang
+++ b/src/main/resources/assets/gtadditions/lang/zh_cn.lang
@@ -494,6 +494,7 @@ recipemap.processing_array.name=Processing Array
 gtadditions.machine.processing_array.name=Processing Array
 gregtech.multiblock.processing_array.description=The Processing Array combines up to %d single block machine(s) in a single multiblock, effectively easing automation.
 gtadditions.multiblock.processing_array.distinct=Distinct Buses:
+gtadditions.multiblock.processing_array.distinct2=[Click %s to Toggle]
 gtadditions.multiblock.processing_array.distinct.yes=§aYes
 gtadditions.multiblock.processing_array.distinct.no=§cNo
 gtadditions.multiblock.processing_array.distinct.info=If enabled, each bus will be treated as fully distinct from each other for recipe lookup. Useful for things like Extruder Shapes, Laser Lenses, etc..


### PR DESCRIPTION
Refactors the Processing Array.

Implements a special Machine access bus that will hold the machines that the Processing Array operates upon. This bus is limited to 1 per Processing Array and will only accept valid machines (namely those that are `ITieredMTE`, which unfortunately also includes the hulls)

The Processing Array will get its machine Stack information from this bus, saving the need to scan all of the input buses to find the machine stack, and also fixing the recipe map detection error, where if the Recipe detection failed, the remainder of the bus would not be scanned to attempt to find another valid machine.

Improves how the Recipe Map of the machine the Processing Array will operate on is detected. This eliminates the need for the large switch statement.

Attempts to implement the recipe caching found in #93. Supersedes #93.

Adds the ability for the number of machines the Processing Array will work on to be configured in the config. Closes #95.

Adds the ability for Machines to be blacklisted in the config via their Recipe Map's unlocalized name

Blacklists LV and MV macerators from getting byproducts in the PA, since they do not have the slots