### PR TITLE
Switch to mavenCentral from Jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         maven { url = "http://files.minecraftforge.net/maven" }
     }
     dependencies {


### PR DESCRIPTION
With the planned eventual retirement of JCenter, this PR switches to mavenCentral for fetching various dependencies.

I have tested this by switching to mavenCentral, running the `cleanCache` task, and then running `setupDecompWorkspace` again.