### PR TITLE
Fix crash due to using Client Sided methods

### DIFF
--- a/src/main/java/gregicadditions/recipes/GeneratorFuels.java
+++ b/src/main/java/gregicadditions/recipes/GeneratorFuels.java
@@ -57,10 +57,10 @@ public class GeneratorFuels {
 
 	private static void removeFuelRecipe(FuelRecipeMap map, FluidStack fluidStack) {
 		if(map.removeRecipe(map.findRecipe(Integer.MAX_VALUE, fluidStack))) {
-			GregicAdditions.LOGGER.info("Removed Generator Recipe for " + map.getLocalizedName() + " for Fluid: " + fluidStack.getLocalizedName());
+			GregicAdditions.LOGGER.info("Removed Generator Recipe for " + map.getUnlocalizedName() + " for Fluid: " + fluidStack.getLocalizedName());
 		}
 		else {
-			GregicAdditions.LOGGER.warn("Failed to remove Generator Recipe for " + map.getLocalizedName() + " for Fluid: " + fluidStack.getLocalizedName());
+			GregicAdditions.LOGGER.warn("Failed to remove Generator Recipe for " + map.getUnlocalizedName() + " for Fluid: " + fluidStack.getLocalizedName());
 		}
 	}
 }


### PR DESCRIPTION
I did not see that the Localized names were marked as client sided only, but it makes sense that they are.