### PR TITLE
Refactor and Cleanup the lang file

### DIFF
--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -494,7 +494,7 @@ gregtech.multiblock.processing_array.description=The Processing Array combines u
 # Assembly Line
 recipemap.assembly_line.name=Assembly Line
 gtadditions.machine.assembly_line.name=Assembly Line
-gregtech.multiblock.assembly_line.description=The Assembly Line is a large multiblock structure consisting of 5 to 16 "slices". In theory, it's large Assembling Machine, used for creating advanced crafting components.
+gregtech.multiblock.assembly_line.description=The Assembly Line is a large multiblock structure consisting of 5 to 17 "slices". In theory, it's a large Assembling Machine, used for creating advanced crafting components.
 
 
 ## Tools

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -33,6 +33,7 @@ metaitem.wafer.naquadah.tooltip=Raw Circuit
 
 # Circuit Tooltips
 metaitem.circuit.basic.tooltip=A Basic Circuit
+metaitem.circuit.good.tooltip=A Good Circuit
 metaitem.circuit.advanced.tooltip=A Good Circuit
 metaitem.circuit.wetware_mainframe.tooltip=An Infinite Circuit
 metaitem.circuit.vacuum_tube.tooltip=A Very Simple Circuit

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -42,7 +42,7 @@ metaitem.circuit.advanced_parts.tooltip=A Basic Circuit
 # Item Tooltips
 metaitem.compressed.fireclay.tooltip=Brick-Shaped
 metaitem.stemcells.tooltip=Raw Intelligence
-metaitem.component.glass.fiber.tooltip=B(SiO2)7
+metaitem.component.glass.fiber.tooltip=B(SiO₂)₇
 metaitem.component.petri.dish.tooltip=For Cultivating Cells
 
 

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -34,7 +34,7 @@ metaitem.wafer.naquadah.tooltip=Raw Circuit
 # Circuit Tooltips
 metaitem.circuit.basic.tooltip=A Basic Circuit
 metaitem.circuit.good.tooltip=A Good Circuit
-metaitem.circuit.advanced.tooltip=A Good Circuit
+metaitem.circuit.advanced.tooltip=An Advanced Circuit
 metaitem.circuit.wetware_mainframe.tooltip=An Infinite Circuit
 metaitem.circuit.vacuum_tube.tooltip=A Very Simple Circuit
 metaitem.circuit.advanced_parts.tooltip=A Basic Circuit

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -145,14 +145,14 @@ gtadditions.machine.cluster_mill.lv.name=Basic Cluster Mill
 gtadditions.machine.cluster_mill.mv.name=Advanced Cluster Mill
 gtadditions.machine.cluster_mill.hv.name=Advanced Cluster Mill II
 gtadditions.machine.cluster_mill.ev.name=Advanced Cluster Mill III
-gtadditions.machine.cluster_mill.iv.name=Elite Cluster Mill
-gtadditions.machine.cluster_mill.luv.name=Elite Cluster Mill I
+gtadditions.machine.cluster_mill.iv.name=Advanced Cluster Mill IV
+gtadditions.machine.cluster_mill.luv.name=Elite Cluster Mill
 gtadditions.machine.cluster_mill.zpm.name=Elite Cluster Mill II
 gtadditions.machine.cluster_mill.uv.name=Elite Cluster Mill III
 
 # Electric Furnace
-gtadditions.machine.electric_furnace.iv.name=Elite Electric Furnace
-gtadditions.machine.electric_furnace.luv.name=Elite Electric Furnace I
+gtadditions.machine.electric_furnace.iv.name=Advanced Electric Furnace IV
+gtadditions.machine.electric_furnace.luv.name=Elite Electric Furnace
 gtadditions.machine.electric_furnace.zpm.name=Elite Electric Furnace II
 gtadditions.machine.electric_furnace.uv.name=Elite Electric Furnace III
 
@@ -163,50 +163,50 @@ gtadditions.machine.macerator.zpm.name=Universal Pulverizer IV
 gtadditions.machine.macerator.uv.name=Universal Pulverizer V
 
 # Alloy Smelter
-gtadditions.machine.alloy_smelter.iv.name=Elite Alloy Smelter
-gtadditions.machine.alloy_smelter.luv.name=Elite Alloy Smelter I
+gtadditions.machine.alloy_smelter.iv.name=Advanced Alloy Smelter IV
+gtadditions.machine.alloy_smelter.luv.name=Elite Alloy Smelter
 gtadditions.machine.alloy_smelter.zpm.name=Elite Alloy Smelter II
 gtadditions.machine.alloy_smelter.uv.name=Elite Alloy Smelter III
 
 # Amplifabricator
-gtadditions.machine.amplifab.iv.name=Elite Amplifabricator
-gtadditions.machine.amplifab.luv.name=Elite Amplifabricator I
+gtadditions.machine.amplifab.iv.name=Advanced Amplifabricator IV
+gtadditions.machine.amplifab.luv.name=Elite Amplifabricator
 gtadditions.machine.amplifab.zpm.name=Elite Amplifabricator II
 gtadditions.machine.amplifab.uv.name=Elite Amplifabricator III
 
 # Arc Furnace
-gtadditions.machine.arc_furnace.iv.name=Elite Arc Furnace
-gtadditions.machine.arc_furnace.luv.name=Elite Arc Furnace I
+gtadditions.machine.arc_furnace.iv.name=Advanced Arc Furnace IV
+gtadditions.machine.arc_furnace.luv.name=Elite Arc Furnace
 gtadditions.machine.arc_furnace.zpm.name=Elite Arc Furnace II
 gtadditions.machine.arc_furnace.uv.name=Elite Arc Furnace III
 
 # Assembling Machine
-gregtech.machine.assembler.iv.name=Elite Assembling Machine
-gtadditions.machine.assembler.luv.name=Elite Assembling Machine I
+gregtech.machine.assembler.iv.name=Advanced Assembling Machine IV
+gtadditions.machine.assembler.luv.name=Elite Assembling Machine
 gtadditions.machine.assembler.zpm.name=Elite Assembling Machine II
 gtadditions.machine.assembler.uv.name=Elite Assembling Machine III
 
 # Autoclave
-gregtech.machine.autoclave.iv.name=Elite Autoclave
-gtadditions.machine.autoclave.luv.name=Elite Autoclave I
+gregtech.machine.autoclave.iv.name=Advanced Autoclave IV
+gtadditions.machine.autoclave.luv.name=Elite Autoclave
 gtadditions.machine.autoclave.zpm.name=Elite Autoclave II
 gtadditions.machine.autoclave.uv.name=Elite Autoclave III
 
 # Bender
-gtadditions.machine.bender.iv.name=Elite Bending Machine
-gtadditions.machine.bender.luv.name=Elite Bending Machine I
+gtadditions.machine.bender.iv.name=Advanced Bending Machine IV
+gtadditions.machine.bender.luv.name=Elite Bending Machine
 gtadditions.machine.bender.zpm.name=Elite Bending Machine II
 gtadditions.machine.bender.uv.name=Elite Bending Machine III
 
 # Brewery
-gtadditions.machine.brewery.iv.name=Elite Brewery
-gtadditions.machine.brewery.luv.name=Elite Brewery I
+gtadditions.machine.brewery.iv.name=Advanced Brewery IV
+gtadditions.machine.brewery.luv.name=Elite Brewery
 gtadditions.machine.brewery.zpm.name=Elite Brewery II
 gtadditions.machine.brewery.uv.name=Elite Brewery III
 
 # Canner
-gtadditions.machine.canner.iv.name=Elite Canning Machine
-gtadditions.machine.canner.luv.name=Elite Canning Machine I
+gtadditions.machine.canner.iv.name=Advanced Canning Machine IV
+gtadditions.machine.canner.luv.name=Elite Canning Machine
 gtadditions.machine.canner.zpm.name=Elite Canning Machine II
 gtadditions.machine.canner.uv.name=Elite Canning Machine III
 
@@ -217,65 +217,65 @@ gtadditions.machine.centrifuge.zpm.name=Turbo Centrifuge V
 gtadditions.machine.centrifuge.uv.name=Turbo Centrifuge VI
 
 # Chemical Bath
-gtadditions.machine.chemical_bath.iv.name=Elite Chemical Bath
-gtadditions.machine.chemical_bath.luv.name=Elite Chemical Bath I
+gtadditions.machine.chemical_bath.iv.name=Advanced Chemical Bath IV
+gtadditions.machine.chemical_bath.luv.name=Elite Chemical Bath
 gtadditions.machine.chemical_bath.zpm.name=Elite Chemical Bath II
 gtadditions.machine.chemical_bath.uv.name=Elite Chemical Bath III
 
 # Chemical Reactor
-gtadditions.machine.chemical_reactor.iv.name=Elite Chemical Reactor
-gtadditions.machine.chemical_reactor.luv.name=Elite Chemical Reactor I
+gtadditions.machine.chemical_reactor.iv.name=Advanced Chemical Reactor IV
+gtadditions.machine.chemical_reactor.luv.name=Elite Chemical Reactor
 gtadditions.machine.chemical_reactor.zpm.name=Elite Chemical Reactor II
 gtadditions.machine.chemical_reactor.uv.name=Elite Chemical Reactor III
 
 # Compressor
 gregtech.machine.compressor.ev.name=Advanced Compressor III
-gtadditions.machine.compressor.iv.name=Elite Compressor
-gtadditions.machine.compressor.luv.name=Elite Compressor I
+gtadditions.machine.compressor.iv.name=Advanced Compressor IV
+gtadditions.machine.compressor.luv.name=Elite Compressor
 gtadditions.machine.compressor.zpm.name=Elite Compressor II
 gtadditions.machine.compressor.uv.name=Elite Compressor III
 
 # Cutter
-gtadditions.machine.cutter.iv.name=Elite Cutting Machine
-gtadditions.machine.cutter.luv.name=Elite Cutting Machine I
+gtadditions.machine.cutter.iv.name=Advanced Cutting Machine IV
+gtadditions.machine.cutter.luv.name=Elite Cutting Machine
 gtadditions.machine.cutter.zpm.name=Elite Cutting Machine II
 gtadditions.machine.cutter.uv.name=Elite Cutting Machine III
 
 # Distillery
-gtadditions.machine.distillery.iv.name=Elite Distillery
-gtadditions.machine.distillery.luv.name=Elite Distillery I
+gtadditions.machine.distillery.iv.name=Advanced Distillery IV
+gtadditions.machine.distillery.luv.name=Elite Distillery
 gtadditions.machine.distillery.zpm.name=Elite Distillery II
 gtadditions.machine.distillery.uv.name=Elite Distillery III
 
 # Electrolyzer
 gregtech.machine.electrolyzer.ev.name=Advanced Electrolyzer III
-gtadditions.machine.electrolyzer.iv.name=Elite Electrolyzer
-gtadditions.machine.electrolyzer.luv.name=Elite Electrolyzer I
+gtadditions.machine.electrolyzer.iv.name=Advanced Electrolyzer IV
+gtadditions.machine.electrolyzer.luv.name=Elite Electrolyzer
 gtadditions.machine.electrolyzer.zpm.name=Elite Electrolyzer II
 gtadditions.machine.electrolyzer.uv.name=Elite Electrolyzer III
 
 # Electromagnetic Separator
-gtadditions.machine.electromagnetic_separator.iv.name=Elite Electromagnetic Separator
-gtadditions.machine.electromagnetic_separator.luv.name=Elite Electromagnetic Separator I
+gtadditions.machine.electromagnetic_separator.iv.name=Advanced Electromagnetic Separator IV
+gtadditions.machine.electromagnetic_separator.luv.name=Elite Electromagnetic Separator
 gtadditions.machine.electromagnetic_separator.zpm.name=Elite Electromagnetic Separator II
 gtadditions.machine.electromagnetic_separator.uv.name=Elite Electromagnetic Separator III
 
 # Extractor
 gregtech.machine.extractor.ev.name=Advanced Extractor III
-gtadditions.machine.extractor.iv.name=Elite Extractor
-gtadditions.machine.extractor.luv.name=Elite Extractor I
+gtadditions.machine.extractor.iv.name=Advanced Extractor IV
+gtadditions.machine.extractor.luv.name=Elite Extractor
 gtadditions.machine.extractor.zpm.name=Elite Extractor II
 gtadditions.machine.extractor.uv.name=Elite Extractor III
 
 # Extruder
-gtadditions.machine.extruder.iv.name=Elite Extruder
-gtadditions.machine.extruder.luv.name=Elite Extruder I
+gtadditions.machine.extruder.iv.name=Advanced Extruder IV
+gtadditions.machine.extruder.luv.name=Elite Extruder
 gtadditions.machine.extruder.zpm.name=Elite Extruder II
 gtadditions.machine.extruder.uv.name=Elite Extruder III
 
 # Fermenter
-gtadditions.machine.fermenter.iv.name=Elite Fermenter
-gtadditions.machine.fermenter.luv.name=Elite Fermenter I
+gtadditions.machine.fermenter.iv.name=Advanced Fermenter IV
+gtadditions.machine.fermenter.luv.name=Elite Fermenter
 gtadditions.machine.fermenter.zpm.name=Elite Fermenter II
 gtadditions.machine.fermenter.uv.name=Elite Fermenter III
 
@@ -286,104 +286,104 @@ gtadditions.machine.fluid_canner.zpm.name=Instant Fluid Canner III
 gtadditions.machine.fluid_canner.uv.name=Instant Fluid Canner IV
 
 # Fluid Extractor
-gtadditions.machine.fluid_extractor.iv.name=Elite Fluid Extractor
-gtadditions.machine.fluid_extractor.luv.name=Elite Fluid Extractor I
+gtadditions.machine.fluid_extractor.iv.name=Advanced Fluid Extractor IV
+gtadditions.machine.fluid_extractor.luv.name=Elite Fluid Extractor
 gtadditions.machine.fluid_extractor.zpm.name=Elite Fluid Extractor II
 gtadditions.machine.fluid_extractor.uv.name=Elite Fluid Extractor III
 
 # Fluid Heater
-gtadditions.machine.fluid_heater.iv.name=Elite Fluid Heater
-gtadditions.machine.fluid_heater.luv.name=Elite Fluid Heater I
+gtadditions.machine.fluid_heater.iv.name=Advanced Fluid Heater IV
+gtadditions.machine.fluid_heater.luv.name=Elite Fluid Heater
 gtadditions.machine.fluid_heater.zpm.name=Elite Fluid Heater II
 gtadditions.machine.fluid_heater.uv.name=Elite Fluid Heater III
 
 # Fluid Solidifier
-gtadditions.machine.fluid_solidifier.iv.name=Elite Fluid Solidifier
-gtadditions.machine.fluid_solidifier.luv.name=Elite Fluid Solidifier I
+gtadditions.machine.fluid_solidifier.iv.name=Advanced Fluid Solidifier IV
+gtadditions.machine.fluid_solidifier.luv.name=Elite Fluid Solidifier
 gtadditions.machine.fluid_solidifier.zpm.name=Elite Fluid Solidifier II
 gtadditions.machine.fluid_solidifier.uv.name=Elite Fluid Solidifier III
 
 # Forge Hammer
-gtadditions.machine.forge_hammer.iv.name=Elite Forge Hammer
-gtadditions.machine.forge_hammer.luv.name=Elite Forge Hammer I
+gtadditions.machine.forge_hammer.iv.name=Advanced Forge Hammer IV
+gtadditions.machine.forge_hammer.luv.name=Elite Forge Hammer
 gtadditions.machine.forge_hammer.zpm.name=Elite Forge Hammer II
 gtadditions.machine.forge_hammer.uv.name=Elite Forge Hammer III
 
 # Forming Press
-gtadditions.machine.forming_press.iv.name=Elite Forming Press
-gtadditions.machine.forming_press.luv.name=Elite Forming Press I
+gtadditions.machine.forming_press.iv.name=Advanced Forming Press IV
+gtadditions.machine.forming_press.luv.name=Elite Forming Press
 gtadditions.machine.forming_press.zpm.name=Elite Forming Press II
 gtadditions.machine.forming_press.uv.name=Elite Forming Press III
 
 # Lathe
-gtadditions.machine.lathe.iv.name=Elite Lathe
-gtadditions.machine.lathe.luv.name=Elite Lathe I
+gtadditions.machine.lathe.iv.name=Advanced Lathe IV
+gtadditions.machine.lathe.luv.name=Elite Lathe
 gtadditions.machine.lathe.zpm.name=Elite Lathe II
 gtadditions.machine.lathe.uv.name=Elite Lathe III
 
 # Microwave
-gtadditions.machine.microwave.iv.name=Elite Microwave
-gtadditions.machine.microwave.luv.name=Elite Microwave I
+gtadditions.machine.microwave.iv.name=Advanced Microwave IV
+gtadditions.machine.microwave.luv.name=Elite Microwave
 gtadditions.machine.microwave.zpm.name=Elite Microwave II
 gtadditions.machine.microwave.uv.name=Elite Microwave III
 
 # Mixer
-gtadditions.machine.mixer.iv.name=Elite Mixer
-gtadditions.machine.mixer.luv.name=Elite Mixer I
+gtadditions.machine.mixer.iv.name=Advanced Mixer IV
+gtadditions.machine.mixer.luv.name=Elite Mixer
 gtadditions.machine.mixer.zpm.name=Elite Mixer II
 gtadditions.machine.mixer.uv.name=Elite Mixer III
 
 # Ore Washer
-gtadditions.machine.ore_washer.iv.name=Elite Ore Washing Plant
-gtadditions.machine.ore_washer.luv.name=Elite Ore Washing Plant I
+gtadditions.machine.ore_washer.iv.name=Advanced Ore Washing Plant IV
+gtadditions.machine.ore_washer.luv.name=Elite Ore Washing Plant
 gtadditions.machine.ore_washer.zpm.name=Elite Ore Washing Plant II
 gtadditions.machine.ore_washer.uv.name=Elite Ore Washing Plant III
 
 # Packer
-gtadditions.machine.packer.iv.name=Elite Packager
-gtadditions.machine.packer.luv.name=Elite Packager I
+gtadditions.machine.packer.iv.name=Advanced Packager IV
+gtadditions.machine.packer.luv.name=Elite Packager
 gtadditions.machine.packer.zpm.name=Elite Packager II
 gtadditions.machine.packer.uv.name=Elite Packager III
 
 # Unpacker
-gtadditions.machine.unpacker.iv.name=Elite Unpackager
-gtadditions.machine.unpacker.luv.name=Elite Unpackager I
+gtadditions.machine.unpacker.iv.name=Advanced Unpackager IV
+gtadditions.machine.unpacker.luv.name=Elite Unpackager
 gtadditions.machine.unpacker.zpm.name=Elite Unpackager II
 gtadditions.machine.unpacker.uv.name=Elite Unpackager III
 
 # Plasma Arc Furnace
-gtadditions.machine.plasma_arc_furnace.iv.name=Elite Plasma Arc Furnace
-gtadditions.machine.plasma_arc_furnace.luv.name=Elite Plasma Arc Furnace I
+gtadditions.machine.plasma_arc_furnace.iv.name=Advanced Plasma Arc Furnace IV
+gtadditions.machine.plasma_arc_furnace.luv.name=Elite Plasma Arc Furnace
 gtadditions.machine.plasma_arc_furnace.zpm.name=Elite Plasma Arc Furnace II
 gtadditions.machine.plasma_arc_furnace.uv.name=Elite Plasma Arc Furnace III
 
 # Polarizer
-gtadditions.machine.polarizer.iv.name=Elite Polarizer
-gtadditions.machine.polarizer.luv.name=Elite Polarizer I
+gtadditions.machine.polarizer.iv.name=Advanced Polarizer IV
+gtadditions.machine.polarizer.luv.name=Elite Polarizer
 gtadditions.machine.polarizer.zpm.name=Elite Polarizer II
 gtadditions.machine.polarizer.uv.name=Elite Polarizer III
 
 # Laser Engraver
-gtadditions.machine.laser_engraver.iv.name=Elite Precision Laser Engraver
-gtadditions.machine.laser_engraver.luv.name=Elite Precision Laser Engraver I
+gtadditions.machine.laser_engraver.iv.name=Advanced Precision Laser Engraver IV
+gtadditions.machine.laser_engraver.luv.name=Elite Precision Laser Engraver
 gtadditions.machine.laser_engraver.zpm.name=Elite Precision Laser Engraver II
 gtadditions.machine.laser_engraver.uv.name=Elite Precision Laser Engraver III
 
 # Shifter
-gtadditions.machine.sifter.iv.name=Elite Sifting Machine
-gtadditions.machine.sifter.luv.name=Elite Sifting Machine I
+gtadditions.machine.sifter.iv.name=Advanced Sifting Machine IV
+gtadditions.machine.sifter.luv.name=Elite Sifting Machine
 gtadditions.machine.sifter.zpm.name=Elite Sifting Machine II
 gtadditions.machine.sifter.uv.name=Elite Sifting Machine III
 
 # Thermal Centrifuge
-gtadditions.machine.thermal_centrifuge.iv.name=Elite Thermal Centrifuge
-gtadditions.machine.thermal_centrifuge.luv.name=Elite Thermal Centrifuge I
+gtadditions.machine.thermal_centrifuge.iv.name=Advanced Thermal Centrifuge IV
+gtadditions.machine.thermal_centrifuge.luv.name=Elite Thermal Centrifuge
 gtadditions.machine.thermal_centrifuge.zpm.name=Elite Thermal Centrifuge II
 gtadditions.machine.thermal_centrifuge.uv.name=Elite Thermal Centrifuge III
 
 # Wiremill
-gtadditions.machine.wiremill.iv.name=Elite Wiremill
-gtadditions.machine.wiremill.luv.name=Elite Wiremill I
+gtadditions.machine.wiremill.iv.name=Advanced Wiremill IV
+gtadditions.machine.wiremill.luv.name=Elite Wiremill
 gtadditions.machine.wiremill.zpm.name=Elite Wiremill II
 gtadditions.machine.wiremill.uv.name=Elite Wiremill III
 
@@ -400,8 +400,8 @@ gtadditions.machine.mass_fab.lv.name=Basic Mass Fabricator
 gtadditions.machine.mass_fab.mv.name=Advanced Mass Fabricator
 gtadditions.machine.mass_fab.hv.name=Advanced Mass Fabricator II
 gtadditions.machine.mass_fab.ev.name=Advanced Mass Fabricator III
-gtadditions.machine.mass_fab.iv.name=Elite Mass Fabricator
-gtadditions.machine.mass_fab.luv.name=Elite Mass Fabricator I
+gtadditions.machine.mass_fab.iv.name=Advanced Mass Fabricator IV
+gtadditions.machine.mass_fab.luv.name=Elite Mass Fabricator
 gtadditions.machine.mass_fab.zpm.name=Elite Mass Fabricator II
 gtadditions.machine.mass_fab.uv.name=Elite Mass Fabricator III
 
@@ -410,8 +410,8 @@ gtadditions.machine.replicator.lv.name=Basic Replicator
 gtadditions.machine.replicator.mv.name=Advanced Replicator
 gtadditions.machine.replicator.hv.name=Advanced Replicator II
 gtadditions.machine.replicator.ev.name=Advanced Replicator III
-gtadditions.machine.replicator.iv.name=Elite Replicator
-gtadditions.machine.replicator.luv.name=Elite Replicator I
+gtadditions.machine.replicator.iv.name=Advanced Replicator IV
+gtadditions.machine.replicator.luv.name=Elite Replicator
 gtadditions.machine.replicator.zpm.name=Elite Replicator II
 gtadditions.machine.replicator.uv.name=Elite Replicator III
 
@@ -431,15 +431,15 @@ gtadditions.machine.bundler.uv.tooltip=Lapinotron 9000
 
 
 # Pump
-gtadditions.machine.pump.iv.name=Elite Pump
-gtadditions.machine.pump.luv.name=Elite Pump I
+gtadditions.machine.pump.iv.name=Advanced Pump IV
+gtadditions.machine.pump.luv.name=Elite Pump
 gtadditions.machine.pump.zpm.name=Elite Pump II
 gtadditions.machine.pump.uv.name=Elite Pump III
 
 # Air Collector
 gregtech.machine.air_collector.ev.name=Advanced Air Collector III
-gtadditions.machine.air_collector.iv.name=Elite Air Collector
-gtadditions.machine.air_collector.luv.name=Elite Air Collector I
+gtadditions.machine.air_collector.iv.name=Advanced Air Collector IV
+gtadditions.machine.air_collector.luv.name=Elite Air Collector
 
 
 ## Multiblocks

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -158,9 +158,13 @@ gtadditions.machine.electric_furnace.uv.name=Elite Electric Furnace III
 
 # Macerator
 gtadditions.machine.macerator.iv.name=Universal Pulverizer II
+gtadditions.machine.macerator.iv.tooltip=Blend-O-Matic 9001
 gtadditions.machine.macerator.luv.name=Universal Pulverizer III
+gtadditions.machine.macerator.luv.tooltip=Blend-O-Matic 9002
 gtadditions.machine.macerator.zpm.name=Universal Pulverizer IV
+gtadditions.machine.macerator.zpm.tooltip=Blend-O-Matic 9003
 gtadditions.machine.macerator.uv.name=Universal Pulverizer V
+gtadditions.machine.macerator.uv.tooltip=Blend-O-Matic 9004
 
 # Alloy Smelter
 gtadditions.machine.alloy_smelter.iv.name=Advanced Alloy Smelter IV
@@ -212,9 +216,13 @@ gtadditions.machine.canner.uv.name=Elite Canning Machine III
 
 # Centrifuge
 gtadditions.machine.centrifuge.iv.name=Turbo Centrifuge III
+gtadditions.machine.centrifuge.iv.tooltip=Molecular Cyclone
 gtadditions.machine.centrifuge.luv.name=Turbo Centrifuge IV
+gtadditions.machine.centrifuge.luv.tooltip=Molecular Cyclone
 gtadditions.machine.centrifuge.zpm.name=Turbo Centrifuge V
+gtadditions.machine.centrifuge.zpm.tooltip=Molecular Cyclone
 gtadditions.machine.centrifuge.uv.name=Turbo Centrifuge VI
+gtadditions.machine.centrifuge.uv.tooltip=Molecular Cyclone
 
 # Chemical Bath
 gtadditions.machine.chemical_bath.iv.name=Advanced Chemical Bath IV
@@ -250,9 +258,13 @@ gtadditions.machine.distillery.uv.name=Elite Distillery III
 # Electrolyzer
 gregtech.machine.electrolyzer.ev.name=Advanced Electrolyzer III
 gtadditions.machine.electrolyzer.iv.name=Advanced Electrolyzer IV
+gtadditions.machine.electrolyzer.iv.tooltip=Molecular Disintegrator E-4905
 gtadditions.machine.electrolyzer.luv.name=Elite Electrolyzer
+gtadditions.machine.electrolyzer.luv.tooltip=Molecular Disintegrator E-4906
 gtadditions.machine.electrolyzer.zpm.name=Elite Electrolyzer II
+gtadditions.machine.electrolyzer.zpm.tooltip=Molecular Disintegrator E-4907
 gtadditions.machine.electrolyzer.uv.name=Elite Electrolyzer III
+gtadditions.machine.electrolyzer.uv.tooltip=Molecular Disintegrator E-4908
 
 # Electromagnetic Separator
 gtadditions.machine.electromagnetic_separator.iv.name=Advanced Electromagnetic Separator IV
@@ -335,9 +347,13 @@ gtadditions.machine.mixer.uv.name=Elite Mixer III
 
 # Ore Washer
 gtadditions.machine.ore_washer.iv.name=Advanced Ore Washing Plant IV
+gtadditions.machine.ore_washer.iv.tooltip=Repurposed Laundry-Washer I-360
 gtadditions.machine.ore_washer.luv.name=Elite Ore Washing Plant
+gtadditions.machine.ore_washer.luv.tooltip=Repurposed Laundry-Washer I-720
 gtadditions.machine.ore_washer.zpm.name=Elite Ore Washing Plant II
+gtadditions.machine.ore_washer.zpm.tooltip=Repurposed Laundry-Washer I-1080
 gtadditions.machine.ore_washer.uv.name=Elite Ore Washing Plant III
+gtadditions.machine.ore_washer.uv.tooltip=Repurposed Laundry-Washer I-1440
 
 # Packer
 gtadditions.machine.packer.iv.name=Advanced Packager IV
@@ -377,9 +393,13 @@ gtadditions.machine.sifter.uv.name=Elite Sifting Machine III
 
 # Thermal Centrifuge
 gtadditions.machine.thermal_centrifuge.iv.name=Advanced Thermal Centrifuge IV
+gtadditions.machine.thermal_centrifuge.iv.tooltip=Blaze Sweatshop T-6350
 gtadditions.machine.thermal_centrifuge.luv.name=Elite Thermal Centrifuge
+gtadditions.machine.thermal_centrifuge.luv.tooltip=Blaze Sweatshop T-6360
 gtadditions.machine.thermal_centrifuge.zpm.name=Elite Thermal Centrifuge II
+gtadditions.machine.thermal_centrifuge.zpm.tooltip=Blaze Sweatshop T-6370
 gtadditions.machine.thermal_centrifuge.uv.name=Elite Thermal Centrifuge III
+gtadditions.machine.thermal_centrifuge.uv.tooltip=Blaze Sweatshop T-6380
 
 # Wiremill
 gtadditions.machine.wiremill.iv.name=Advanced Wiremill IV
@@ -407,13 +427,21 @@ gtadditions.machine.mass_fab.uv.name=Elite Mass Fabricator III
 
 # Replicator
 gtadditions.machine.replicator.lv.name=Basic Replicator
+gtadditions.machine.replicator.lv.tooltip=Producing The Purest Of Elements
 gtadditions.machine.replicator.mv.name=Advanced Replicator
+gtadditions.machine.replicator.mv.tooltip=Producing The Purest Of Elements
 gtadditions.machine.replicator.hv.name=Advanced Replicator II
+gtadditions.machine.replicator.hv.tooltip=Producing The Purest Of Elements
 gtadditions.machine.replicator.ev.name=Advanced Replicator III
+gtadditions.machine.replicator.ev.tooltip=Producing The Purest Of Elements
 gtadditions.machine.replicator.iv.name=Advanced Replicator IV
+gtadditions.machine.replicator.iv.tooltip=Producing The Purest Of Elements
 gtadditions.machine.replicator.luv.name=Elite Replicator
+gtadditions.machine.replicator.luv.tooltip=Producing The Purest Of Elements
 gtadditions.machine.replicator.zpm.name=Elite Replicator II
+gtadditions.machine.replicator.zpm.tooltip=Producing The Purest Of Elements
 gtadditions.machine.replicator.uv.name=Elite Replicator III
+gtadditions.machine.replicator.uv.tooltip=Producing The Purest Of Elements
 
 # Bundler
 recipemap.bundler.name=Wire Bundling

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -1,599 +1,94 @@
-metaitem.assembly.normal.name=Processor Assembly
-metaitem.assembly.normal.tooltip=An Advanced Circuit
-metaitem.assembly.nano.name=Nanoprocessor Assembly
-metaitem.assembly.nano.tooltip=An Extreme Circuit
-metaitem.assembly.wetware.name=Wetwareprocessor Assembly
-metaitem.assembly.wetware.tooltip=An Ultimate Circuit
-metaitem.board.coated.name=Coated Circuit Board
+## Shadows of Greg en_us lang file
+
+## Item Tooltips
+
+# Board Tooltips
 metaitem.board.coated.tooltip=A Basic Board
-metaitem.board.epoxy.name=Epoxy Circuit Board
 metaitem.board.epoxy.tooltip=An Advanced Board
-metaitem.board.fiber-reinforced.name=Fiber-Reinforced Circuit Board
-metaitem.board.fiber-reinforced.tooltip=An Extreme Board
-metaitem.board.multilayer.fiber-reinforced.name=Multilayer Fiber-Reinforced Circuit Board
-metaitem.board.multilayer.fiber-reinforced.tooltip=An Elite Board
-metaitem.board.phenolic.name=Phenolic Circuit Board
+metaitem.board.fiber_reinforced.tooltip=An Extreme Board
+metaitem.board.multilayer.fiber_reinforced.tooltip=An Elite Board
 metaitem.board.phenolic.tooltip=A Good Board
-metaitem.board.plastic.name=Plastic Circuit Board
 metaitem.board.plastic.tooltip=A Good Board
-metaitem.board.wetware.name=Wetware Lifesupport Circuit Board
 metaitem.board.wetware.tooltip=The Board That Keeps Life
-metaitem.boule.silicon.name=Monocrystalline Silicon Boule
-metaitem.boule.silicon.tooltip=Raw Circuit
-metaitem.boule.glowstone.name=Glowstone doped Monocrystalline Silicon Boule
-metaitem.boule.glowstone.tooltip=Raw Circuit
-metaitem.boule.naquadah.name=Naquadah doped Monocrystalline Silicon Boule
-metaitem.boule.naquadah.tooltip=Raw Circuit
-metaitem.brick.coke.name=Coke Oven Brick
-metaitem.brick.fireclay.name=Firebrick
-metaitem.circuit.advanced.regular.name=Advanced Circuit
-metaitem.circuit.advanced.regular.tooltip=An Advanced Circuit
-metaitem.circuit.good.regular.name=Good Integrated Circuit
-metaitem.circuit.good.regular.tooltip=A Good Circuit
-metaitem.circuit.basic.regular.name=Basic Circuit
-metaitem.circuit.basic.regular.tooltip=A Basic Circuit
-metaitem.circuit.vacuum.tube.name=Vacuum Tube
-metaitem.circuit.vacuum.tube.tooltip=A Very Simple Circuit
-metaitem.component.diode.name=Diode
+
+# Electronic Components Tooltips
 metaitem.component.diode.tooltip=Basic Electronic Component
-metaitem.component.capacitor.name=Capacitor
-metaitem.component.capacitor.tooltip=Electronic Component
-metaitem.component.glass.fiber.name=Glass Fiber
-metaitem.component.glass.fiber.tooltip=B(SiO2)7
-metaitem.component.glass.tube.name=Glass Tube
-metaitem.component.petri.dish.name=Petri Dish
-metaitem.component.petri.dish.tooltip=For Cultivating Cells
-metaitem.component.resistor.name=Resistor
+metaitem.component.capacitor.tooltip=Basic Electronic Component
 metaitem.component.resistor.tooltip=Basic Electronic Component
-metaitem.component.small.coil.name=Small Coil
-metaitem.component.small.coil.tooltip=Basic Electronic Component
-metaitem.component.smd.capacitor.name=SMD Capacitor
+metaitem.component.small_coil.tooltip=Basic Electronic Component
 metaitem.component.smd.capacitor.tooltip=Electronic Component
-metaitem.component.smd.diode.name=SMD Diode
 metaitem.component.smd.diode.tooltip=Electronic Component
-metaitem.component.smd.resistor.name=SMD Resistor
 metaitem.component.smd.resistor.tooltip=Electronic Component
-metaitem.component.smd.transistor.name=SMD Transistor
 metaitem.component.smd.transistor.tooltip=Electronic Component
-metaitem.component.transistor.name=Transistor
 metaitem.component.transistor.tooltip=Basic Electronic Component
-metaitem.compressed.clay.name=Unfired Clay Brick
-metaitem.compressed.fireclay.name=Compressed Fireclay
-metaitem.compressed.fireclay.tooltip=Brick-Shaped
-metaitem.computer.crystal.name=Ultimate Crystalcomputer
-metaitem.computer.crystal.tooltip=An Ultimate Circuit
-metaitem.computer.nano.name=Elite Nanocomputer
-metaitem.computer.nano.tooltip=An Elite Circuit
-metaitem.computer.quantum.name=Master Quantumcomputer
-metaitem.computer.quantum.tooltip=A Master Circuit
-metaitem.computer.wetware.name=Wetware Supercomputer
-metaitem.computer.wetware.tooltip=A Super Circuit
-metaitem.mainframe.crystal.name=Crystalprocessor Mainframe
-metaitem.mainframe.crystal.tooltip=A Super Circuit
-metaitem.mainframe.nano.name=Nanoprocessor Mainframe
-metaitem.mainframe.nano.tooltip=A Master Circuit
-metaitem.mainframe.normal.name=Mainframe
-metaitem.mainframe.normal.tooltip=An Elite Circuit
-metaitem.mainframe.quantum.name=Quantumprocessor Mainframe
-metaitem.mainframe.quantum.tooltip=An Ultimate Circuit
-metaitem.mainframe.wetware.name=Wetware Mainframe
-metaitem.mainframe.wetware.tooltip=An Infinite Circuit
-metaitem.plate.asoc.name=ASoC
-metaitem.plate.asoc.tooltip=Advanced System on a Chip
-metaitem.plate.circuit.name=Integrated Logic Circuit
-metaitem.plate.circuit.tooltip=Integrated Circuit
-metaitem.plate.cpu.name=Central Processing Unit
-metaitem.plate.cpu.tooltip=Integrated Circuit
-metaitem.plate.hpic.name=High Power IC
-metaitem.plate.hpic.tooltip=High Power Circuit
-metaitem.plate.nand.name=NAND Memory Chip
-metaitem.plate.nand.tooltip=Integrated Circuit
-metaitem.plate.nanocpu.name=Nanocomponent Central Processing Unit
-metaitem.plate.nanocpu.tooltip=Power Circuit
-metaitem.plate.nor.name=NOR Memory Chip
-metaitem.plate.nor.tooltip=Integrated Circuit
-metaitem.plate.pic.name=Power IC
-metaitem.plate.pic.tooltip=Power Circuit
-metaitem.plate.qbit.name=QBit Processing Unit
-metaitem.plate.qbit.tooltip=Quantum CPU
-metaitem.plate.ram.name=Random Access Memory Chip
-metaitem.plate.ram.tooltip=Integrated Circuit
-metaitem.plate.soc.name=SoC
-metaitem.plate.soc.tooltip=System on a Chip
-metaitem.processor.crystal.name=Crystalprocessor
-metaitem.processor.crystal.tooltip=An Elite Circuit
-metaitem.processor.nano.name=Nanoprocessor
-metaitem.processor.nano.tooltip=An Advanced Circuit
-metaitem.processor.quantum.name=Quantumprocessor
-metaitem.processor.quantum.tooltip=An Extreme Circuit
-metaitem.processor.wetware.name=Wetwareprocessor
-metaitem.processor.wetware.tooltip=A Master Circuit
-metaitem.wafer.asoc.name=ASoC Wafer
-metaitem.wafer.asoc.tooltip=Raw Circuit
-metaitem.wafer.circuit.name=Integrated Logic Circuit (Wafer)
-metaitem.wafer.circuit.tooltip=Raw Circuit
-metaitem.wafer.cpu.name=Central Processing Unit (wafer)
-metaitem.wafer.cpu.tooltip=Raw Circuit
-metaitem.wafer.glowstone.name=Glowstone doped Wafer
-metaitem.wafer.glowstone.tooltip=Raw Circuit
-metaitem.wafer.hpic.name=HPIC Wafer
-metaitem.wafer.hpic.tooltip=Raw Circuit
-metaitem.wafer.naquadah.name=Naquadah doped Wafer
-metaitem.wafer.naquadah.tooltip=Raw Circuit
-metaitem.wafer.nand.name=NAND Memory Chip (Wafer)
-metaitem.wafer.nand.tooltip=Raw Circuit
-metaitem.wafer.nanocpu.name=NanoCPU Wafer
-metaitem.wafer.nanocpu.tooltip=Raw Circuit
-metaitem.wafer.nor.name=NOR Memory Chip (wafer)
-metaitem.wafer.nor.tooltip=Raw Circuit
-metaitem.wafer.pic.name=PIC Wafer
-metaitem.wafer.pic.tooltip=Raw Circuit
-metaitem.wafer.qbit.name=QBit Wafer
-metaitem.wafer.qbit.tooltip=Raw Circuit
-metaitem.wafer.ram.name=Random Acccess Memory Chip (Wafer)
-metaitem.wafer.ram.tooltip=Raw Circuit
-metaitem.wafer.silicon.name=Wafer
+
+# Wafers and Components Tooltips
+metaitem.boule.silicon.tooltip=Raw Circuit
+metaitem.boule.glowstone.tooltip=Raw Circuit
+metaitem.boule.naquadah.tooltip=Raw Circuit
+metaitem.plate.qbit_central_processing_unit.tooltip=Quantum CPU
 metaitem.wafer.silicon.tooltip=Raw Circuit
-metaitem.wafer.soc.name=SoC Wafer
-metaitem.wafer.soc.tooltip=Raw Circuit
-metaitem.form.acacia.name=Acacia Brick Form
-metaitem.form.birch.name=Birch Brick Form
-metaitem.form.darkoak.name=Dark Oak Brick Form
-metaitem.form.jungle.name=Jungle Brick Form
-metaitem.form.oak.name=Oak Brick Form
-metaitem.form.spruce.name=Spruce Brick Form
-metaitem.carbon.fibers.name=Raw Carbon Fibers
-metaitem.plate.mixed.metal.name=Mixed Metal plate
-metaitem.plate.advanced.alloy.name=Advanced Alloy Plate
-metaitem.crystal.raw.name=Raw Crystal Chip
-metaitem.crystal.raw.tooltip=Raw Crystal Processor
-metaitem.crystal.cpu.name=Crystal Processing Unit
-metaitem.crystal.cpu.tooltip=Crystal CPU
-metaitem.crystal.soc.name=Crystal SoC
-metaitem.crystal.soc.tooltip=Crystal System on a Chip
-metaitem.stemcells.name=Stemcells
+metaitem.wafer.glowstone.tooltip=Raw Circuit
+metaitem.wafer.naquadah.tooltip=Raw Circuit
+
+# Circuit Tooltips
+metaitem.circuit.basic.tooltip=A Basic Circuit
+metaitem.circuit.advanced.tooltip=A Good Circuit
+metaitem.circuit.wetware_mainframe.tooltip=An Infinite Circuit
+metaitem.circuit.vacuum_tube.tooltip=A Very Simple Circuit
+
+# Item Tooltips
+metaitem.compressed.fireclay.tooltip=Brick-Shaped
 metaitem.stemcells.tooltip=Raw Intelligence
-metaitem.crystal.lapotron.name=Lapotron Crystal
-metaitem.plate.iridium.alloy.name=Iridium Alloy Plate
-metaitem.plate.iridium.alloy.uncompressed.name=Uncompressed Iridium Alloy Plate
-metaitem.neutron.reflector.name=Neutron Reflector
-metaitem.processor.neuro.name=Neuro Processing Unit
+metaitem.component.glass.fiber.tooltip=B(SiO2)7
+metaitem.component.petri.dish.tooltip=For Cultivating Cells
 
-metaitem.electrode.apatite.name=Apatine Electrode
-metaitem.electrode.blaze.name=Blazing Electrode
-metaitem.electrode.bronze.name=Bronze Electrode
-metaitem.electrode.copper.name=Copper Electrode
-metaitem.electrode.diamond.name=Diamantine Electrode
-metaitem.electrode.emerald.name=Emerald Electrode
-metaitem.electrode.ender.name=Ender Electrode
-metaitem.electrode.gold.name=Golden Electrode
-metaitem.electrode.iron.name=Iron Electrode
-metaitem.electrode.lapis.name=Lapis Electrode
-metaitem.electrode.obsidian.name=Obsidian Electrode
-metaitem.electrode.orchid.name=Orchid Electrode
-metaitem.electrode.rubber.name=Rubberised Electrode
-metaitem.electrode.tin.name=Tin Electrode
 
+## Item Names/Renames
+
+# Renaming Boules
+metaitem.boule.silicon.name=Monocrystalline Silicon Boule
+metaitem.boule.glowstone.name=Glowstone-doped Monocrystalline Silicon Boule
+metaitem.boule.naquadah.name=Naquadah-doped Monocrystalline Silicon Boule
+
+# Naming Multiblock Parts
+tile.ga_multiblock_casing.tungstensteel_gearbox_casing.name=Assembly Line Casing
+tile.ga_transparent_casing.reinforced_glass.name=Reinforced Glass
+
+# Naming Batteries
 metaitem.energy.module.name=Energy Module
 metaitem.energy.cluster.name=Energy Cluster
 metaitem.max.battery.name=MAX Battery
 
-gtadditions.machine.circuit_assembler.lv.name=Basic Circuit Assembling Machine
-gtadditions.machine.circuit_assembler.mv.name=Advanced Circuit Assembling Machine
-gtadditions.machine.circuit_assembler.hv.name=Advanced Circuit Assembling Machine II
-gtadditions.machine.circuit_assembler.ev.name=Advanced Circuit Assembling Machine III
-gtadditions.machine.circuit_assembler.iv.name=Advanced Circuit Assembling Machine IV
-gtadditions.machine.circuit_assembler.luv.name=Advanced Circuit Assembling Machine V
-gtadditions.machine.circuit_assembler.zpm.name=Advanced Circuit Assembling Machine VI
-gtadditions.machine.circuit_assembler.uv.name=Advanced Circuit Assembling Machine VII
+# Naming Items
+metaitem.component.petri.dish.name=Petri Dish
+metaitem.compressed.clay.name=Unfired Clay Brick
+metaitem.stemcells.name=Stem cells
+metaitem.credit.darmstadtium.name=Neutronium Credit
+metaitem.rubber_drop.name=Sticky Resin
+metaitem.component.glass.fiber.name=Glass Fiber
+metaitem.compressed.coke.clay.name=Compressed Coke Clay
 
-gtadditions.machine.cluster_mill.lv.name=Basic Cluster Mill
-gtadditions.machine.cluster_mill.mv.name=Advanced Cluster Mill
-gtadditions.machine.cluster_mill.hv.name=Advanced Cluster Mill II
-gtadditions.machine.cluster_mill.ev.name=Advanced Cluster Mill III
-gtadditions.machine.cluster_mill.iv.name=Advanced Cluster Mill IV
-gtadditions.machine.cluster_mill.luv.name=Advanced Cluster Mill V
-gtadditions.machine.cluster_mill.zpm.name=Advanced Cluster Mill VI
-gtadditions.machine.cluster_mill.uv.name=Advanced Cluster Mill VII
+# Renaming Circuits
+metaitem.circuit.integrated.name=Programmed Circuit
+metaitem.circuit.advanced.name=Integrated Processor
+metaitem.circuit.crystal_processor.name=Crystal Processor
+metaitem.circuit.nano_processor.name=Nano Processor
+metaitem.circuit.quantum_processor.name=Quantum Processor
+metaitem.processor.neuro.name=Neuro Processing Unit
 
-gtadditions.machine.electric_furnace.iv.name=Electron Excitement Processor
-gtadditions.machine.electric_furnace.luv.name=Electron Excitement Processor
-gtadditions.machine.electric_furnace.zpm.name=Electron Excitement Processor
-gtadditions.machine.electric_furnace.uv.name=Electron Excitement Processor
+# Naming Schematics
+metaitem.schematic.dust.name=Schematic (Dust)
+metaitem.schematic.3by3.name=Schematic (3x3)
+metaitem.schematic.2by2.name=Schematic (2x2)
+metaitem.schematic.name=Blank Schematic
 
-gtadditions.machine.macerator.iv.name=Blend-O-Matic 9001
-gtadditions.machine.macerator.luv.name=Blend-O-Matic 9002
-gtadditions.machine.macerator.zpm.name=Blend-O-Matic 9003
-gtadditions.machine.macerator.uv.name=Blend-O-Matic 9004
-
-gtadditions.machine.alloy_smelter.iv.name=Advanced Alloy Smelter IV
-gtadditions.machine.alloy_smelter.luv.name=Advanced Alloy Smelter V
-gtadditions.machine.alloy_smelter.zpm.name=Advanced Alloy Smelter VI
-gtadditions.machine.alloy_smelter.uv.name=Advanced Alloy Smelter VII
-
-gtadditions.machine.amplifab.iv.name=Advanced Amplifabricator IV
-gtadditions.machine.amplifab.luv.name=Advanced Amplifabricator V
-gtadditions.machine.amplifab.zpm.name=Advanced Amplifabricator VI
-gtadditions.machine.amplifab.uv.name=Advanced Amplifabricator VII
-
-gtadditions.machine.arc_furnace.iv.name=Advanced Arc Furnace IV
-gtadditions.machine.arc_furnace.luv.name=Advanced Arc Furnace V
-gtadditions.machine.arc_furnace.zpm.name=Advanced Arc Furnace VI
-gtadditions.machine.arc_furnace.uv.name=Advanced Arc Furnace VII
-
-gtadditions.machine.assembler.iv.name=Advanced Assembling Machine IV
-gtadditions.machine.assembler.luv.name=Advanced Assembling Machine V
-gtadditions.machine.assembler.zpm.name=Advanced Assembling Machine VI
-gtadditions.machine.assembler.uv.name=Advanced Assembling Machine VII
-
-gtadditions.machine.autoclave.iv.name=Advanced Autoclave IV
-gtadditions.machine.autoclave.luv.name=Advanced Autoclave V
-gtadditions.machine.autoclave.zpm.name=Advanced Autoclave VI
-gtadditions.machine.autoclave.uv.name=Advanced Autoclave VII
-
-gtadditions.machine.bender.iv.name=Advanced Bending Machine IV
-gtadditions.machine.bender.luv.name=Advanced Bending Machine V
-gtadditions.machine.bender.zpm.name=Advanced Bending Machine VI
-gtadditions.machine.bender.uv.name=Advanced Bending Machine VII
-
-gtadditions.machine.brewery.iv.name=Advanced Brewery IV
-gtadditions.machine.brewery.luv.name=Advanced Brewery V
-gtadditions.machine.brewery.zpm.name=Advanced Brewery VI
-gtadditions.machine.brewery.uv.name=Advanced Brewery VII
-
-gtadditions.machine.canner.iv.name=Advanced Canning Machine IV
-gtadditions.machine.canner.luv.name=Advanced Canning Machine V
-gtadditions.machine.canner.zpm.name=Advanced Canning Machine VI
-gtadditions.machine.canner.uv.name=Advanced Canning Machine VII
-
-gregtech.machine.centrifuge.ev.name=Molecular Separator
-gtadditions.machine.centrifuge.iv.name=Molecular Cyclone
-gtadditions.machine.centrifuge.luv.name=Molecular Cyclone
-gtadditions.machine.centrifuge.zpm.name=Molecular Cyclone
-gtadditions.machine.centrifuge.uv.name=Molecular Cyclone
-
-gtadditions.machine.chemical_bath.iv.name=Advanced Chemical Bath IV
-gtadditions.machine.chemical_bath.luv.name=Advanced Chemical Bath V
-gtadditions.machine.chemical_bath.zpm.name=Advanced Chemical Bath VI
-gtadditions.machine.chemical_bath.uv.name=Advanced Chemical Bath VII
-
-gtadditions.machine.chemical_reactor.iv.name=Advanced Chemical Reactor IV
-gtadditions.machine.chemical_reactor.luv.name=Advanced Chemical Reactor V
-gtadditions.machine.chemical_reactor.zpm.name=Advanced Chemical Reactor VI
-gtadditions.machine.chemical_reactor.uv.name=Advanced Chemical Reactor VII
-
-gregtech.machine.compressor.ev.name=Advanced Compressor III
-gtadditions.machine.compressor.iv.name=Singularity Compressor
-gtadditions.machine.compressor.luv.name=Singularity Compressor
-gtadditions.machine.compressor.zpm.name=Singularity Compressor
-gtadditions.machine.compressor.uv.name=Singularity Compressor
-
-gtadditions.machine.cutter.iv.name=Advanced Cutting Machine IV
-gtadditions.machine.cutter.luv.name=Advanced Cutting Machine V
-gtadditions.machine.cutter.zpm.name=Advanced Cutting Machine VI
-gtadditions.machine.cutter.uv.name=Advanced Cutting Machine VII
-
-gtadditions.machine.distillery.iv.name=Advanced Distillery IV
-gtadditions.machine.distillery.luv.name=Advanced Distillery V
-gtadditions.machine.distillery.zpm.name=Advanced Distillery VI
-gtadditions.machine.distillery.uv.name=Advanced Distillery VII
-
-gregtech.machine.electrolyzer.ev.name=Advanced Electrolyzer III
-gtadditions.machine.electrolyzer.iv.name=Molecular Disintegrator E-4905
-gtadditions.machine.electrolyzer.luv.name=Molecular Disintegrator E-4906
-gtadditions.machine.electrolyzer.zpm.name=Molecular Disintegrator E-4907
-gtadditions.machine.electrolyzer.uv.name=Molecular Disintegrator E-4908
-
-gtadditions.machine.electromagnetic_separator.iv.name=Advanced Electromagnetic Separator IV
-gtadditions.machine.electromagnetic_separator.luv.name=Advanced Electromagnetic Separator V
-gtadditions.machine.electromagnetic_separator.zpm.name=Advanced Electromagnetic Separator VI
-gtadditions.machine.electromagnetic_separator.uv.name=Advanced Electromagnetic Separator VII
-
-gregtech.machine.extractor.ev.name=Advanced Extractor III
-gtadditions.machine.extractor.iv.name=Vacuum Extractor
-gtadditions.machine.extractor.luv.name=Vacuum Extractor
-gtadditions.machine.extractor.zpm.name=Vacuum Extractor
-gtadditions.machine.extractor.uv.name=Vacuum Extractor
-
-gtadditions.machine.extruder.iv.name=Advanced Extruder IV
-gtadditions.machine.extruder.luv.name=Advanced Extruder V
-gtadditions.machine.extruder.zpm.name=Advanced Extruder VI
-gtadditions.machine.extruder.uv.name=Advanced Extruder VII
-
-gtadditions.machine.fermenter.iv.name=Advanced Fermenter IV
-gtadditions.machine.fermenter.luv.name=Advanced Fermenter V
-gtadditions.machine.fermenter.zpm.name=Advanced Fermenter VI
-gtadditions.machine.fermenter.uv.name=Advanced Fermenter VII
-
-gtadditions.machine.fluid_canner.iv.name=Instant Fluid Canner
-gtadditions.machine.fluid_canner.luv.name=Instant Fluid Canner
-gtadditions.machine.fluid_canner.zpm.name=Instant Fluid Canner
-gtadditions.machine.fluid_canner.uv.name=Instant Fluid Canner
-
-gtadditions.machine.fluid_extractor.iv.name=Advanced Fluid Extractor IV
-gtadditions.machine.fluid_extractor.luv.name=Advanced Fluid Extractor V
-gtadditions.machine.fluid_extractor.zpm.name=Advanced Fluid Extractor VI
-gtadditions.machine.fluid_extractor.uv.name=Advanced Fluid Extractor VII
-
-gtadditions.machine.fluid_heater.iv.name=Advanced Fluid Heater IV
-gtadditions.machine.fluid_heater.luv.name=Advanced Fluid Heater V
-gtadditions.machine.fluid_heater.zpm.name=Advanced Fluid Heater VI
-gtadditions.machine.fluid_heater.uv.name=Advanced Fluid Heater VII
-
-gtadditions.machine.fluid_solidifier.iv.name=Advanced Fluid Solidifier IV
-gtadditions.machine.fluid_solidifier.luv.name=Advanced Fluid Solidifier V
-gtadditions.machine.fluid_solidifier.zpm.name=Advanced Fluid Solidifier VI
-gtadditions.machine.fluid_solidifier.uv.name=Advanced Fluid Solidifier VII
-
-gtadditions.machine.forge_hammer.iv.name=Advanced Forge Hammer IV
-gtadditions.machine.forge_hammer.luv.name=Advanced Forge Hammer V
-gtadditions.machine.forge_hammer.zpm.name=Advanced Forge Hammer VI
-gtadditions.machine.forge_hammer.uv.name=Advanced Forge Hammer VII
-
-gtadditions.machine.forming_press.iv.name=Advanced Forming Press IV
-gtadditions.machine.forming_press.luv.name=Advanced Forming Press V
-gtadditions.machine.forming_press.zpm.name=Advanced Forming Press VI
-gtadditions.machine.forming_press.uv.name=Advanced Forming Press VII
-
-gtadditions.machine.lathe.iv.name=Advanced Lathe IV
-gtadditions.machine.lathe.luv.name=Advanced Lathe V
-gtadditions.machine.lathe.zpm.name=Advanced Lathe VI
-gtadditions.machine.lathe.uv.name=Advanced Lathe VII
-
-gtadditions.machine.microwave.iv.name=Advanced Microwave IV
-gtadditions.machine.microwave.luv.name=Advanced Microwave V
-gtadditions.machine.microwave.zpm.name=Advanced Microwave VI
-gtadditions.machine.microwave.uv.name=Advanced Microwave VII
-
-gtadditions.machine.mixer.iv.name=Advanced Mixer IV
-gtadditions.machine.mixer.luv.name=Advanced Mixer V
-gtadditions.machine.mixer.zpm.name=Advanced Mixer VI
-gtadditions.machine.mixer.uv.name=Advanced Mixer VII
-
-gtadditions.machine.ore_washer.iv.name=Repurposed Laundry-Washer I-360
-gtadditions.machine.ore_washer.luv.name=Repurposed Laundry-Washer I-720
-gtadditions.machine.ore_washer.zpm.name=Repurposed Laundry-Washer I-1080
-gtadditions.machine.ore_washer.uv.name=Repurposed Laundry-Washer I-1440
-
-gtadditions.machine.packer.iv.name=Boxinator
-gtadditions.machine.packer.luv.name=Boxinator
-gtadditions.machine.packer.zpm.name=Boxinator
-gtadditions.machine.packer.uv.name=Boxinator
-
-gtadditions.machine.unpacker.iv.name=Unboxinator
-gtadditions.machine.unpacker.luv.name=Unboxinator
-gtadditions.machine.unpacker.zpm.name=Unboxinator
-gtadditions.machine.unpacker.uv.name=Unboxinator
-
-gtadditions.machine.plasma_arc_furnace.iv.name=Advanced Plasma Arc Furnace IV
-gtadditions.machine.plasma_arc_furnace.luv.name=Advanced Plasma Arc Furnace V
-gtadditions.machine.plasma_arc_furnace.zpm.name=Advanced Plasma Arc Furnace VI
-gtadditions.machine.plasma_arc_furnace.uv.name=Advanced Plasma Arc Furnace VII
-
-gtadditions.machine.polarizer.iv.name=Advanced Polarizer IV
-gtadditions.machine.polarizer.luv.name=Advanced Polarizer V
-gtadditions.machine.polarizer.zpm.name=Advanced Polarizer VI
-gtadditions.machine.polarizer.uv.name=Advanced Polarizer VII
-
-gtadditions.machine.laser_engraver.iv.name=Advanced Precision Laser Engraver IV
-gtadditions.machine.laser_engraver.luv.name=Advanced Precision Laser Engraver V
-gtadditions.machine.laser_engraver.zpm.name=Advanced Precision Laser Engraver VI
-gtadditions.machine.laser_engraver.uv.name=Advanced Precision Laser Engraver VII
-
-gtadditions.machine.sifter.iv.name=Advanced Sifting Machine IV
-gtadditions.machine.sifter.luv.name=Advanced Sifting Machine V
-gtadditions.machine.sifter.zpm.name=Advanced Sifting Machine VI
-gtadditions.machine.sifter.uv.name=Advanced Sifting Machine VII
-
-gtadditions.machine.thermal_centrifuge.iv.name=Blaze Sweatshop T-6350
-gtadditions.machine.thermal_centrifuge.luv.name=Blaze Sweatshop T-6360
-gtadditions.machine.thermal_centrifuge.zpm.name=Blaze Sweatshop T-6370
-gtadditions.machine.thermal_centrifuge.uv.name=Blaze Sweatshop T-6380
-
-gtadditions.machine.wiremill.iv.name=Advanced Wiremill IV
-gtadditions.machine.wiremill.luv.name=Advanced Wiremill V
-gtadditions.machine.wiremill.zpm.name=Advanced Wiremill VI
-gtadditions.machine.wiremill.uv.name=Advanced Wiremill VII
-
-gtadditions.machine.distill_tower.name=[Deprecated] Distillation Tower
-gtadditions.machine.assembly_line.name=Assembly Line
-gtadditions.machine.processing_array.name=Processing Array
-gtadditions.machine.coke_oven.name=[Deprecated] Coke Oven
-gtadditions.machine.cracker_unit.name=[Deprecated] Cracking Unit
-
-gtadditions.machine.naquadah_reactor.mk1.name=Naquadah Reactor Mk. 1
-gtadditions.machine.naquadah_reactor.mk2.name=Naquadah Reactor Mk. 2
-gtadditions.machine.naquadah_reactor.mk3.name=Naquadah Reactor Mk. 3
-gtadditions.machine.naquadah_reactor.mk4.name=Naquadah Reactor Mk. 4
-
-gtadditions.machine.mass_fab.lv.name=Basic Mass Fabricator
-gtadditions.machine.mass_fab.mv.name=Advanced Mass Fabricator
-gtadditions.machine.mass_fab.hv.name=Advanced Mass Fabricator II
-gtadditions.machine.mass_fab.ev.name=Advanced Mass Fabricator III
-gtadditions.machine.mass_fab.iv.name=Advanced Mass Fabricator IV
-gtadditions.machine.mass_fab.luv.name=Advanced Mass Fabricator V
-gtadditions.machine.mass_fab.zpm.name=Advanced Mass Fabricator VI
-gtadditions.machine.mass_fab.uv.name=Advanced Mass Fabricator VII
-
-gtadditions.machine.replicator.lv.name=Basic Replicator
-gtadditions.machine.replicator.mv.name=Advanced Replicator
-gtadditions.machine.replicator.hv.name=Advanced Replicator II
-gtadditions.machine.replicator.ev.name=Advanced Replicator III
-gtadditions.machine.replicator.iv.name=Advanced Replicator IV
-gtadditions.machine.replicator.luv.name=Advanced Replicator V
-gtadditions.machine.replicator.zpm.name=Advanced Replicator VI
-gtadditions.machine.replicator.uv.name=Advanced Replicator VII
-
-gtadditions.machine.pump.iv.name=Advanced Pump IV
-gtadditions.machine.pump.luv.name=Advanced Pump V
-gtadditions.machine.pump.zpm.name=Advanced Pump VI
-gtadditions.machine.pump.uv.name=Advanced Pump VII
-
-gregtech.machine.air_collector.ev.name=Advanced Air Collector III
-gtadditions.machine.air_collector.iv.name=Atmosphere Collector
-gtadditions.machine.air_collector.luv.name=Atmosphere Collector
-
-gtadditions.machine.replicator.tooltip=Producing The Purest Of Elements
-
-gtadditions.machine.fusion_reactor.luv.name=Fusion Reactor Computer Mark 1
-gtadditions.machine.fusion_reactor.zpm.name=Fusion Reactor Computer Mark 2
-gtadditions.machine.fusion_reactor.uv.name=Fusion Reactor Computer Mark 3
-
-gtadditions.machine.coke_item_bus.name=[Deprecated] Coke Oven Chute
-gtadditions.machine.coke_fluid_hatch.name=[Deprecated] Coke Oven Faucet
-
-tile.ga_multiblock_casing.coke_oven_bricks.name=Coke Oven Bricks
-tile.ga_multiblock_casing.tungstensteel_gearbox_casing.name=Assembly Line Casing
-tile.ga_transparent_casing.reinforced_glass.name=Reinforced Glass
-
-metaitem.tool.bending_cylinder.name=%s Bending Cylinder
-metaitem.tool.bending_cylinder_small.name=Small %s Bending Cylinder
-
-recipemap.cluster_mill.name=Cluster Mill
-recipemap.circuit_assembler.name=Circuit Assembler
-recipemap.coke_oven.name=[Deprecated] Coke Oven
-recipemap.distill_tower.name=[Deprecated] Distillation Tower
-recipemap.assembly_line.name=Assembly Line
-recipemap.processing_array.name=Processing Array
-recipemap.naquadah_reactor.name=Naquadah Reactor Fuels
-recipemap.replicator.name=Replicator
-recipemap.mass_fab.name=Mass Fabricator
-recipemap.cracker_unit.name=[Deprecated] Cracking Recipes
-recipemap.bundler.name=Wire Bundling
-
-recipemap.plasma_generator.name=Plasma Turbine Fuels
-
-material.brick=Brick
-material.fireclay=Fireclay
-material.coke=Coal Coke
-material.phosphorous_pentoxide=Phosphorous Pentoxide
-material.phosphoric_acid=Phosphoric Acid
-material.polyvinyl_acetate=Polyvinyl Acetate
-material.phenol=Phenol
-material.bisphenol_a=Bisphenol A
-material.epoxid=Epoxy Resin
-material.reinforced_epoxy_resin=Fiber-Reinforced Epoxy Resin
-material.borosilicate_glass=Borosilicate Glass
-material.polyvinyl_chloride=Polyvinyl Chloride
-material.vinyl_chloride=Vinyl Chloride
-material.ethylene=Ethylene
-material.charcoal_byproducts=Charcoal Byproducts
-material.benzene=Benzene
-material.wood_gas=Wood Gas
-material.wood_vinegar=Wood Vinegar
-material.wood_tar=Wood Tar
-material.sodium_hydroxide=Sodium Hydroxide
-material.quicklime=Quicklime
-material.acetone=Acetone
-material.sulfur_trioxide=Sulfur Trioxide
-material.sulfur_dioxide=Sulfur Dioxide
-material.glycerol=Glycerol
-material.fish_oil=Fish Oil
-material.methanol=Methanol
-material.carbon_monoxide=Carbon Monoxide
-material.nitro_fuel=Cetane-Boosted Diesel
-material.diluted_sulfuric_acid=Diluted Sulfuric Acid
-material.sodium_bisulfate=Sodium Bisulfate
-material.chloroform=Chloroform
-material.diluted_hydrochloric_acid=Diluted Hydrochloric Acid
-material.hypochlorous_acid=Hypochlorous Acid
-material.ammonia=Ammonia
-material.chloramine=Chloramine
-material.dimethylamine=Dimethylamine
-material.dimethylhidrazine=1,1-Dimethylhydrazine
-material.rocket_fuel=Rocket Fuel
-material.dinitrogen_tetroxide=Dinitrogen Tetroxide
-material.silicon_rubber=Silicone Rubber
-material.polydimethylsiloxane=Polydimethylsiloxane
-material.dimethyldichlorosilane=Dimethyldichlorosilane
-material.styrene=Styrene
-material.polystyrene=Polystyrene
-material.butadiene=Butadiene
-material.raw_styrene_butadiene_rubber=Raw Styrene-Butadiene Rubber
-material.styrene_butadiene_rubber=Styrene-Butadiene Rubber
-material.dichlorobenzene=Dichlorobenzene
-material.hydrochloric_acid=Hydrochloric Acid
-material.acetic_acid=Acetic Acid
-material.fermented_biomass=Fermented Biomass
-material.potash=Potash
-material.soda_ash=Soda Ash
-material.hydrofluoric_acid=Hydrofluoric Acid
-material.nitric_oxide=Nitric Oxide
-material.methyl_acetate=Methyl Acetate
-material.ethenone=Ethenone
-material.tetranitromethane=Tetranitromethane
-material.bio_diesel=Bio Diesel
-material.raw_growth_medium=Raw Growth Medium
-material.sterilized_growth_medium=Sterilized Growth Medium
-material.meat=Meat
-material.cooked_meat=Cooked Meat
-material.vinyl_acetate=Vinyl Acetate
-material.gallium_arsenide=Gallium Arsenide
-material.polyphenylene_sulfide=Polyphenylene Sulfide
-material.nickel_sulfate_water_solution=Nickel Sulfate Water Solution
-material.blue_vitriol_water_solution=Blue Vitriol Water Solution
-material.propane=Propane
-material.propene=Propene
-material.ethane=Ethane
-material.butene=Butene
-material.butane=Butane
-material.calcium_acetate=Calcium Acetate Solution
-material.cumene=Cumene
-material.indium_gallium_phosphide=Indium Gallium Phosphide
-material.platinum_group_sludge=Platinum Group Sludge
-material.ferrite_mixture=Ferrite Mixture
-material.nickel_zinc_ferrite=Nickel Zinc Ferrite
-material.indium_concentrate=Indium Concentrate
-material.lead_zinc_solution=Lead-Zinc Solution
-material.tetrafluoroethylene=Tetrafluoroethylene
-material.salt_water=Salt Water
-material.hydrocracked_ethane=Hydro-Cracked Ethane
-material.hydrocracked_ethylene=Hydro-Cracked Ethylene
-material.hydrocracked_propene=Hydro-Cracked Propene
-material.hydrocracked_propane=Hydro-Cracked Propane
-material.hydrocracked_light_fuel=Hydro-Cracked Light Fuel
-material.hydrocracked_butane=Hydro-Cracked Butane
-material.hydrocracked_naphtha=Hydro-Cracked Naphtha
-material.hydrocracked_heavy_fuel=Hydro-Cracked Heavy Fuel
-material.hydrocracked_gas=Hydro-Cracked Refinery Gas
-material.hydrocracked_butene=Hydro-Cracked Butene
-material.hydrocracked_butadiene=Hydro-Cracked Butadiene
-material.steamcracked_ethane=Steam-Cracked Ethane
-material.steamcracked_ethylene=Steam-Cracked Ethylene
-material.steamcracked_propene=Steam-Cracked Propene
-material.steamcracked_propane=Steam-Cracked Propane
-material.cracked_light_fuel=Steam-Cracked Light Fuel
-material.steamcracked_butane=Steam-Cracked Butane
-material.steamcracked_naphtha=Steam-Cracked Naphtha
-material.cracked_heavy_fuel=Steam-Cracked Heavy Fuel
-material.steamcracked_gas=Steam-Cracked Refinery Gas
-material.steamcracked_butene=Steam-Cracked Butene
-material.steamcracked_butadiene=Steam-Cracked Butadiene
-material.biogas=Bio Gas
-material.chloromethane=Chloromethane
-material.allyl_chloride=Allyl Chloride
-material.isoprene=Isoprene
-material.massicot=Massicot
-material.antimony_trioxide=Antimony Trioxide
-material.zincite=Zincite
-material.cobalt_oxide=Cobalt Oxide
-material.arsenic_trioxide=Arsenic Trioxide
-material.cupric_oxide=Cupric Oxide
-material.ferrosilite=Ferrosilite
-material.magnesia=Magnesia
-material.ga_sodium_sulfide=Sodium Sulfide
-material.neutral_matter=Neutral Matter
-material.positive_matter=Positive Matter
-material.neutronium=Neutronium
-material.plasma=Plasma Confinement
-material.lignite_coke=Lignite Coke
-
+# Renaming Rubber Components
 item.epoxid.ingot=Epoxy Resin Bar
 item.epoxid.dustTiny=Tiny Pile of Epoxy Resin Pulp
 item.epoxid.dustSmall=Small Pile of Epoxy Resin Pulp
 item.epoxid.dust=Epoxy Resin Pulp
 item.epoxid.nugget=Epoxy Resin Chip
-item.epoxid.plateDense=Dense Epoxy Resin Sheet
 item.epoxid.plate=Epoxy Resin Sheet
 item.epoxid.foil=Thin Epoxy Resin Sheet
 item.reinforced_epoxy_resin.ingot=Fiber-Reinforced Epoxy Resin Bar
@@ -601,17 +96,12 @@ item.reinforced_epoxy_resin.dustTiny=Tiny Pile of Fiber-Reinforced Epoxy Resin P
 item.reinforced_epoxy_resin.dustSmall=Small Pile of Fiber-Reinforced Epoxy Resin Pulp
 item.reinforced_epoxy_resin.dust=Fiber-Reinforced Epoxy Resin Pulp
 item.reinforced_epoxy_resin.nugget=Fiber-Reinforced Epoxy Resin Chip
-item.reinforced_epoxy_resin.plateDense=Dense Fiber-Reinforced Epoxy Resin Sheet
 item.reinforced_epoxy_resin.plate=Fiber-Reinforced Epoxy Resin Sheet
-item.reinforced_epoxy_resin.foil=Thin Fiber-Reinforced Epoxy Resin Sheet
 item.borosilicate_glass.ingot=Borosilicate Glass Bar
 item.borosilicate_glass.dustTiny=Tiny Pile of Borosilicate Glass Pulp
 item.borosilicate_glass.dustSmall=Small Pile of Borosilicate Glass Pulp
 item.borosilicate_glass.dust=Borosilicate Glass Pulp
 item.borosilicate_glass.nugget=Borosilicate Glass Chip
-item.borosilicate_glass.plateDense=Dense Borosilicate Glass Sheet
-item.borosilicate_glass.plate=Borosilicate Glass Sheet
-item.borosilicate_glass.foil=Thin Borosilicate Glass Sheet
 item.polyvinyl_chloride.ingot=Polyvinyl Chloride Bar
 item.polyvinyl_chloride.dustTiny=Tiny Pile of Polyvinyl Chloride Pulp
 item.polyvinyl_chloride.dustSmall=Small Pile of Polyvinyl Chloride Pulp
@@ -620,20 +110,18 @@ item.polyvinyl_chloride.nugget=Polyvinyl Chloride Chip
 item.polyvinyl_chloride.plateDense=Dense Polyvinyl Chloride Sheet
 item.polyvinyl_chloride.plate=Polyvinyl Chloride Sheet
 item.polyvinyl_chloride.foil=Thin Polyvinyl Chloride Sheet
-item.silicone_rubber.ingot=Silicone Rubber Bar
-item.silicone_rubber.dustTiny=Tiny Pile of Silicone Rubber Pulp
-item.silicone_rubber.dustSmall=Small Pile of Silicone Rubber Pulp
-item.silicone_rubber.dust=Silicone Rubber Pulp
-item.silicone_rubber.nugget=Silicone Rubber Chip
-item.silicone_rubber.plateDense=Dense Silicone Rubber Sheet
-item.silicone_rubber.plate=Silicone Rubber Sheet
-item.silicone_rubber.foil=Thin Silicone Rubber Sheet
+item.silicon_rubber.ingot=Silicone Rubber Bar
+item.silicon_rubber.dustTiny=Tiny Pile of Silicone Rubber Pulp
+item.silicon_rubber.dustSmall=Small Pile of Silicone Rubber Pulp
+item.silicon_rubber.dust=Silicone Rubber Pulp
+item.silicon_rubber.nugget=Silicone Rubber Chip
+item.silicon_rubber.plate=Silicone Rubber Sheet
+item.silicon_rubber.foil=Thin Silicone Rubber Sheet
 item.polystyrene.ingot=Polystyrene Bar
 item.polystyrene.dustTiny=Tiny Pile of Polystyrene Pulp
 item.polystyrene.dustSmall=Small Pile of Polystyrene Pulp
 item.polystyrene.dust=Polystyrene Pulp
 item.polystyrene.nugget=Polystyrene Chip
-item.polystyrene.plateDense=Dense Polystyrene Sheet
 item.polystyrene.plate=Polystyrene Sheet
 item.polystyrene.foil=Thin Polystyrene Sheet
 item.styrene_butadiene_rubber.ingot=Styrene-Butadiene Rubber Bar
@@ -641,50 +129,361 @@ item.styrene_butadiene_rubber.dustTiny=Tiny Pile of Styrene-Butadiene Rubber Pul
 item.styrene_butadiene_rubber.dustSmall=Small Pile of Styrene-Butadiene Rubber Pulp
 item.styrene_butadiene_rubber.dust=Styrene-Butadiene Rubber Pulp
 item.styrene_butadiene_rubber.nugget=Styrene-Butadiene Rubber Chip
-item.styrene_butadiene_rubber.plateDense=Dense Styrene-Butadiene Rubber Sheet
 item.styrene_butadiene_rubber.plate=Styrene-Butadiene Rubber Sheet
-item.styrene_butadiene_rubber.foil=Thin Styrene-Butadiene Rubber Sheet
+
+# Renaming Meat parts
 item.meat.dustTiny=Tiny Pile of Mince Meat
 item.meat.dustSmall=Small Pile of Mince Meat
 item.meat.dust=Mince Meat
 
-gregtech.multiblock.coke_oven.description=The Coke Oven is a 3x3 multiblock structure used for turning Coal into Coal Coke, Lignite into Lignite Coke and Logs into Charcoal, with Creosote Oil as a byproduct.
-gregtech.multiblock.assembly_line.description=The Assembly Line is a large multiblock structure consisting of 5 to 16 "slices". In theory, it's large Assembling Machine, used for creating advanced crafting components.
-gregtech.multiblock.processing_array.description=The Processing Array combines up to 16 single block machines in a single multiblock, effectively easing automation.
-gregtech.multiblock.distill_tower.description=The GA Distillation Tower is a multiblock structure consisting of 2-12 layers. It's used for distilling fluids, but unlike the Distillery, gives you multiple outputs per input, including item outputs. Every layer has a different output.
+
+## Higher Tier Machines
+
+# Cluster Mill
+recipemap.cluster_mill.name=Cluster Mill
+gtadditions.machine.cluster_mill.lv.name=Basic Cluster Mill
+gtadditions.machine.cluster_mill.mv.name=Advanced Cluster Mill
+gtadditions.machine.cluster_mill.hv.name=Advanced Cluster Mill II
+gtadditions.machine.cluster_mill.ev.name=Advanced Cluster Mill III
+gtadditions.machine.cluster_mill.iv.name=Elite Cluster Mill
+gtadditions.machine.cluster_mill.luv.name=Elite Cluster Mill I
+gtadditions.machine.cluster_mill.zpm.name=Elite Cluster Mill II
+gtadditions.machine.cluster_mill.uv.name=Elite Cluster Mill III
+
+# Electric Furnace
+gtadditions.machine.electric_furnace.iv.name=Elite Electric Furnace
+gtadditions.machine.electric_furnace.luv.name=Elite Electric Furnace I
+gtadditions.machine.electric_furnace.zpm.name=Elite Electric Furnace II
+gtadditions.machine.electric_furnace.uv.name=Elite Electric Furnace III
+
+# Macerator
+gtadditions.machine.macerator.iv.name=Universal Pulverizer II
+gtadditions.machine.macerator.luv.name=Universal Pulverizer III
+gtadditions.machine.macerator.zpm.name=Universal Pulverizer IV
+gtadditions.machine.macerator.uv.name=Universal Pulverizer V
+
+# Alloy Smelter
+gtadditions.machine.alloy_smelter.iv.name=Elite Alloy Smelter
+gtadditions.machine.alloy_smelter.luv.name=Elite Alloy Smelter I
+gtadditions.machine.alloy_smelter.zpm.name=Elite Alloy Smelter II
+gtadditions.machine.alloy_smelter.uv.name=Elite Alloy Smelter III
+
+# Amplifabricator
+gtadditions.machine.amplifab.iv.name=Elite Amplifabricator
+gtadditions.machine.amplifab.luv.name=Elite Amplifabricator I
+gtadditions.machine.amplifab.zpm.name=Elite Amplifabricator II
+gtadditions.machine.amplifab.uv.name=Elite Amplifabricator III
+
+# Arc Furnace
+gtadditions.machine.arc_furnace.iv.name=Elite Arc Furnace
+gtadditions.machine.arc_furnace.luv.name=Elite Arc Furnace I
+gtadditions.machine.arc_furnace.zpm.name=Elite Arc Furnace II
+gtadditions.machine.arc_furnace.uv.name=Elite Arc Furnace III
+
+# Assembling Machine
+gregtech.machine.assembler.iv.name=Elite Assembling Machine
+gtadditions.machine.assembler.luv.name=Elite Assembling Machine I
+gtadditions.machine.assembler.zpm.name=Elite Assembling Machine II
+gtadditions.machine.assembler.uv.name=Elite Assembling Machine III
+
+# Autoclave
+gregtech.machine.autoclave.iv.name=Elite Autoclave
+gtadditions.machine.autoclave.luv.name=Elite Autoclave I
+gtadditions.machine.autoclave.zpm.name=Elite Autoclave II
+gtadditions.machine.autoclave.uv.name=Elite Autoclave III
+
+# Bender
+gtadditions.machine.bender.iv.name=Elite Bending Machine
+gtadditions.machine.bender.luv.name=Elite Bending Machine I
+gtadditions.machine.bender.zpm.name=Elite Bending Machine II
+gtadditions.machine.bender.uv.name=Elite Bending Machine III
+
+# Brewery
+gtadditions.machine.brewery.iv.name=Elite Brewery
+gtadditions.machine.brewery.luv.name=Elite Brewery I
+gtadditions.machine.brewery.zpm.name=Elite Brewery II
+gtadditions.machine.brewery.uv.name=Elite Brewery III
+
+# Canner
+gtadditions.machine.canner.iv.name=Elite Canning Machine
+gtadditions.machine.canner.luv.name=Elite Canning Machine I
+gtadditions.machine.canner.zpm.name=Elite Canning Machine II
+gtadditions.machine.canner.uv.name=Elite Canning Machine III
+
+# Centrifuge
+gtadditions.machine.centrifuge.iv.name=Turbo Centrifuge III
+gtadditions.machine.centrifuge.luv.name=Turbo Centrifuge IV
+gtadditions.machine.centrifuge.zpm.name=Turbo Centrifuge V
+gtadditions.machine.centrifuge.uv.name=Turbo Centrifuge VI
+
+# Chemical Bath
+gtadditions.machine.chemical_bath.iv.name=Elite Chemical Bath
+gtadditions.machine.chemical_bath.luv.name=Elite Chemical Bath I
+gtadditions.machine.chemical_bath.zpm.name=Elite Chemical Bath II
+gtadditions.machine.chemical_bath.uv.name=Elite Chemical Bath III
+
+# Chemical Reactor
+gtadditions.machine.chemical_reactor.iv.name=Elite Chemical Reactor
+gtadditions.machine.chemical_reactor.luv.name=Elite Chemical Reactor I
+gtadditions.machine.chemical_reactor.zpm.name=Elite Chemical Reactor II
+gtadditions.machine.chemical_reactor.uv.name=Elite Chemical Reactor III
+
+# Compressor
+gregtech.machine.compressor.ev.name=Advanced Compressor III
+gtadditions.machine.compressor.iv.name=Elite Compressor
+gtadditions.machine.compressor.luv.name=Elite Compressor I
+gtadditions.machine.compressor.zpm.name=Elite Compressor II
+gtadditions.machine.compressor.uv.name=Elite Compressor III
+
+# Cutter
+gtadditions.machine.cutter.iv.name=Elite Cutting Machine
+gtadditions.machine.cutter.luv.name=Elite Cutting Machine I
+gtadditions.machine.cutter.zpm.name=Elite Cutting Machine II
+gtadditions.machine.cutter.uv.name=Elite Cutting Machine III
+
+# Distillery
+gtadditions.machine.distillery.iv.name=Elite Distillery
+gtadditions.machine.distillery.luv.name=Elite Distillery I
+gtadditions.machine.distillery.zpm.name=Elite Distillery II
+gtadditions.machine.distillery.uv.name=Elite Distillery III
+
+# Electrolyzer
+gregtech.machine.electrolyzer.ev.name=Advanced Electrolyzer III
+gtadditions.machine.electrolyzer.iv.name=Elite Electrolyzer
+gtadditions.machine.electrolyzer.luv.name=Elite Electrolyzer I
+gtadditions.machine.electrolyzer.zpm.name=Elite Electrolyzer II
+gtadditions.machine.electrolyzer.uv.name=Elite Electrolyzer III
+
+# Electromagnetic Separator
+gtadditions.machine.electromagnetic_separator.iv.name=Elite Electromagnetic Separator
+gtadditions.machine.electromagnetic_separator.luv.name=Elite Electromagnetic Separator I
+gtadditions.machine.electromagnetic_separator.zpm.name=Elite Electromagnetic Separator II
+gtadditions.machine.electromagnetic_separator.uv.name=Elite Electromagnetic Separator III
+
+# Extractor
+gregtech.machine.extractor.ev.name=Advanced Extractor III
+gtadditions.machine.extractor.iv.name=Elite Extractor
+gtadditions.machine.extractor.luv.name=Elite Extractor I
+gtadditions.machine.extractor.zpm.name=Elite Extractor II
+gtadditions.machine.extractor.uv.name=Elite Extractor III
+
+# Extruder
+gtadditions.machine.extruder.iv.name=Elite Extruder
+gtadditions.machine.extruder.luv.name=Elite Extruder I
+gtadditions.machine.extruder.zpm.name=Elite Extruder II
+gtadditions.machine.extruder.uv.name=Elite Extruder III
+
+# Fermenter
+gtadditions.machine.fermenter.iv.name=Elite Fermenter
+gtadditions.machine.fermenter.luv.name=Elite Fermenter I
+gtadditions.machine.fermenter.zpm.name=Elite Fermenter II
+gtadditions.machine.fermenter.uv.name=Elite Fermenter III
+
+# Fluid Canner
+gtadditions.machine.fluid_canner.iv.name=Instant Fluid Canner
+gtadditions.machine.fluid_canner.luv.name=Instant Fluid Canner II
+gtadditions.machine.fluid_canner.zpm.name=Instant Fluid Canner III
+gtadditions.machine.fluid_canner.uv.name=Instant Fluid Canner IV
+
+# Fluid Extractor
+gtadditions.machine.fluid_extractor.iv.name=Elite Fluid Extractor
+gtadditions.machine.fluid_extractor.luv.name=Elite Fluid Extractor I
+gtadditions.machine.fluid_extractor.zpm.name=Elite Fluid Extractor II
+gtadditions.machine.fluid_extractor.uv.name=Elite Fluid Extractor III
+
+# Fluid Heater
+gtadditions.machine.fluid_heater.iv.name=Elite Fluid Heater
+gtadditions.machine.fluid_heater.luv.name=Elite Fluid Heater I
+gtadditions.machine.fluid_heater.zpm.name=Elite Fluid Heater II
+gtadditions.machine.fluid_heater.uv.name=Elite Fluid Heater III
+
+# Fluid Solidifier
+gtadditions.machine.fluid_solidifier.iv.name=Elite Fluid Solidifier
+gtadditions.machine.fluid_solidifier.luv.name=Elite Fluid Solidifier I
+gtadditions.machine.fluid_solidifier.zpm.name=Elite Fluid Solidifier II
+gtadditions.machine.fluid_solidifier.uv.name=Elite Fluid Solidifier III
+
+# Forge Hammer
+gtadditions.machine.forge_hammer.iv.name=Elite Forge Hammer
+gtadditions.machine.forge_hammer.luv.name=Elite Forge Hammer I
+gtadditions.machine.forge_hammer.zpm.name=Elite Forge Hammer II
+gtadditions.machine.forge_hammer.uv.name=Elite Forge Hammer III
+
+# Forming Press
+gtadditions.machine.forming_press.iv.name=Elite Forming Press
+gtadditions.machine.forming_press.luv.name=Elite Forming Press I
+gtadditions.machine.forming_press.zpm.name=Elite Forming Press II
+gtadditions.machine.forming_press.uv.name=Elite Forming Press III
+
+# Lathe
+gtadditions.machine.lathe.iv.name=Elite Lathe
+gtadditions.machine.lathe.luv.name=Elite Lathe I
+gtadditions.machine.lathe.zpm.name=Elite Lathe II
+gtadditions.machine.lathe.uv.name=Elite Lathe III
+
+# Microwave
+gtadditions.machine.microwave.iv.name=Elite Microwave
+gtadditions.machine.microwave.luv.name=Elite Microwave I
+gtadditions.machine.microwave.zpm.name=Elite Microwave II
+gtadditions.machine.microwave.uv.name=Elite Microwave III
+
+# Mixer
+gtadditions.machine.mixer.iv.name=Elite Mixer
+gtadditions.machine.mixer.luv.name=Elite Mixer I
+gtadditions.machine.mixer.zpm.name=Elite Mixer II
+gtadditions.machine.mixer.uv.name=Elite Mixer III
+
+# Ore Washer
+gtadditions.machine.ore_washer.iv.name=Elite Ore Washing Plant
+gtadditions.machine.ore_washer.luv.name=Elite Ore Washing Plant I
+gtadditions.machine.ore_washer.zpm.name=Elite Ore Washing Plant II
+gtadditions.machine.ore_washer.uv.name=Elite Ore Washing Plant III
+
+# Packer
+gtadditions.machine.packer.iv.name=Elite Packager
+gtadditions.machine.packer.luv.name=Elite Packager I
+gtadditions.machine.packer.zpm.name=Elite Packager II
+gtadditions.machine.packer.uv.name=Elite Packager III
+
+# Unpacker
+gtadditions.machine.unpacker.iv.name=Elite Unpackager
+gtadditions.machine.unpacker.luv.name=Elite Unpackager I
+gtadditions.machine.unpacker.zpm.name=Elite Unpackager II
+gtadditions.machine.unpacker.uv.name=Elite Unpackager III
+
+# Plasma Arc Furnace
+gtadditions.machine.plasma_arc_furnace.iv.name=Elite Plasma Arc Furnace
+gtadditions.machine.plasma_arc_furnace.luv.name=Elite Plasma Arc Furnace I
+gtadditions.machine.plasma_arc_furnace.zpm.name=Elite Plasma Arc Furnace II
+gtadditions.machine.plasma_arc_furnace.uv.name=Elite Plasma Arc Furnace III
+
+# Polarizer
+gtadditions.machine.polarizer.iv.name=Elite Polarizer
+gtadditions.machine.polarizer.luv.name=Elite Polarizer I
+gtadditions.machine.polarizer.zpm.name=Elite Polarizer II
+gtadditions.machine.polarizer.uv.name=Elite Polarizer III
+
+# Laser Engraver
+gtadditions.machine.laser_engraver.iv.name=Elite Precision Laser Engraver
+gtadditions.machine.laser_engraver.luv.name=Elite Precision Laser Engraver I
+gtadditions.machine.laser_engraver.zpm.name=Elite Precision Laser Engraver II
+gtadditions.machine.laser_engraver.uv.name=Elite Precision Laser Engraver III
+
+# Shifter
+gtadditions.machine.sifter.iv.name=Elite Sifting Machine
+gtadditions.machine.sifter.luv.name=Elite Sifting Machine I
+gtadditions.machine.sifter.zpm.name=Elite Sifting Machine II
+gtadditions.machine.sifter.uv.name=Elite Sifting Machine III
+
+# Thermal Centrifuge
+gtadditions.machine.thermal_centrifuge.iv.name=Elite Thermal Centrifuge
+gtadditions.machine.thermal_centrifuge.luv.name=Elite Thermal Centrifuge I
+gtadditions.machine.thermal_centrifuge.zpm.name=Elite Thermal Centrifuge II
+gtadditions.machine.thermal_centrifuge.uv.name=Elite Thermal Centrifuge III
+
+# Wiremill
+gtadditions.machine.wiremill.iv.name=Elite Wiremill
+gtadditions.machine.wiremill.luv.name=Elite Wiremill I
+gtadditions.machine.wiremill.zpm.name=Elite Wiremill II
+gtadditions.machine.wiremill.uv.name=Elite Wiremill III
+
+# Naquadah Reactor
+recipemap.naquadah_reactor.name=Naquadah Reactor Fuels
+gtadditions.machine.naquadah_reactor.mk1.name=Naquadah Reactor Mk. 1
+gtadditions.machine.naquadah_reactor.mk2.name=Naquadah Reactor Mk. 2
+gtadditions.machine.naquadah_reactor.mk3.name=Naquadah Reactor Mk. 3
+gtadditions.machine.naquadah_reactor.mk4.name=Naquadah Reactor Mk. 4
+
+# Mass Fabricator
+recipemap.mass_fab.name=Mass Fabricator
+gtadditions.machine.mass_fab.lv.name=Basic Mass Fabricator
+gtadditions.machine.mass_fab.mv.name=Advanced Mass Fabricator
+gtadditions.machine.mass_fab.hv.name=Advanced Mass Fabricator II
+gtadditions.machine.mass_fab.ev.name=Advanced Mass Fabricator III
+gtadditions.machine.mass_fab.iv.name=Elite Mass Fabricator
+gtadditions.machine.mass_fab.luv.name=Elite Mass Fabricator I
+gtadditions.machine.mass_fab.zpm.name=Elite Mass Fabricator II
+gtadditions.machine.mass_fab.uv.name=Elite Mass Fabricator III
+
+# Replicator
+gtadditions.machine.replicator.lv.name=Basic Replicator
+gtadditions.machine.replicator.mv.name=Advanced Replicator
+gtadditions.machine.replicator.hv.name=Advanced Replicator II
+gtadditions.machine.replicator.ev.name=Advanced Replicator III
+gtadditions.machine.replicator.iv.name=Elite Replicator
+gtadditions.machine.replicator.luv.name=Elite Replicator I
+gtadditions.machine.replicator.zpm.name=Elite Replicator II
+gtadditions.machine.replicator.uv.name=Elite Replicator III
+
+# Bundler
+recipemap.bundler.name=Wire Bundling
+gtadditions.machine.bundler.lv.name=Basic Bundler
+gtadditions.machine.bundler.mv.name=Advanced Bundler
+gtadditions.machine.bundler.hv.name=Advanced Bundler II
+gtadditions.machine.bundler.ev.name=Advanced Bundler III
+gtadditions.machine.bundler.iv.name=Advanced Bundler IV
+gtadditions.machine.bundler.luv.name=Elite Bundler
+gtadditions.machine.bundler.luv.tooltip=Lapinotron 3000
+gtadditions.machine.bundler.zpm.name=Elite Bundler II
+gtadditions.machine.bundler.zpm.tooltip=Lapinotron 6000
+gtadditions.machine.bundler.uv.name=Elite Bundler III
+gtadditions.machine.bundler.uv.tooltip=Lapinotron 9000
+
+
+# Pump
+gtadditions.machine.pump.iv.name=Elite Pump
+gtadditions.machine.pump.luv.name=Elite Pump I
+gtadditions.machine.pump.zpm.name=Elite Pump II
+gtadditions.machine.pump.uv.name=Elite Pump III
+
+# Air Collector
+gregtech.machine.air_collector.ev.name=Advanced Air Collector III
+gtadditions.machine.air_collector.iv.name=Elite Air Collector
+gtadditions.machine.air_collector.luv.name=Elite Air Collector I
+
+
+## Multiblocks
+
+# Plasma Turbine
+recipemap.plasma_generator.name=Plasma Turbine Fuels
+
+# Fusion Reactor
+gtadditions.machine.fusion_reactor.luv.name=Fusion Reactor Computer Mark 1
+gtadditions.machine.fusion_reactor.zpm.name=Fusion Reactor Computer Mark 2
+gtadditions.machine.fusion_reactor.uv.name=Fusion Reactor Computer Mark 3
 gregtech.multiblock.fusion_reactor_mk1.description=The Fusion Reactor Mark 1 is a large multiblock structure used for fusing elements into heavier ones. The Mark 1 Fusion Reactor can use LuV, ZPM or UV Energy Hatches. For every Hatch it has its buffer increases by 10M EU.
 gregtech.multiblock.fusion_reactor_mk2.description=The Fusion Reactor Mark 2 is a large multiblock structure used for fusing elements into heavier ones. The Mark 2 Fusion Reactor can use ZPM or UV Energy Hatches. For every Hatch it has its buffer increases by 20M EU.
 gregtech.multiblock.fusion_reactor_mk3.description=The Fusion Reactor Mark 3 is a large multiblock structure used for fusing elements into heavier ones. The Mark 3 Fusion Reactor can only use UV Energy Hatches. For every Hatch it has its buffer increases by 40M EU.
 gregtech.multiblock.fusion_reactor.heat=Heat: %d
 
+# Processing Array
+recipemap.processing_array.name=Processing Array
+gtadditions.machine.processing_array.name=Processing Array
+gregtech.multiblock.processing_array.description=The Processing Array combines up to 16 single block machines in a single multiblock, effectively easing automation.
+
+# Assembly Line
+recipemap.assembly_line.name=Assembly Line
+gtadditions.machine.assembly_line.name=Assembly Line
+gregtech.multiblock.assembly_line.description=The Assembly Line is a large multiblock structure consisting of 5 to 16 "slices". In theory, it's large Assembling Machine, used for creating advanced crafting components.
+
+
+## Tools
+metaitem.tool.bending_cylinder.name=%s Bending Cylinder
+metaitem.tool.bending_cylinder_small.name=Small %s Bending Cylinder
+
+
+## Materials
 item.material.oreprefix.plateCurved=Curved %s Plate
-item.material.oreprefix.ingotDouble=Double %s Ingot
-item.material.oreprefix.pipeGaSmall=Small %s Pipe
-item.material.oreprefix.pipeGa=%s Pipe
-item.material.oreprefix.pipeGaLarge=Large %s Pipe
+material.fish_oil=Fish Oil
+material.meat=Meat
+material.neutral_matter=Neutral Matter
+material.positive_matter=Positive Matter
+material.neutronium=Neutronium
+material.lignite_coke=Lignite Coke
+material.coke=Coal Coke
 
-metaitem.circuit.parts.advanced.name=Microprocessor
-metaitem.circuit.parts.advanced.tooltip=A Basic Circuit
-metaitem.circuit.integrated.name=Programmed Circuit
-metaitem.circuit.basic.name=Integrated Logic Circuit
-metaitem.circuit.basic.tooltip=A Basic Circuit
-metaitem.circuit.advanced.name=Integrated Processor
-metaitem.circuit.advanced.tooltip=A Good Circuit
-metaitem.circuit.master.name=Crystalprocessor Assembly
-metaitem.circuit.master.tooltip=A Master Circuit
-metaitem.circuit.elite.name=Quantumprocessor Assembly
-metaitem.circuit.elite.tooltip=An Elite Circuit
-metaitem.circuit.data.name=Workstation
-metaitem.circuit.data.tooltip=An Extreme Circuit
-metaitem.circuit.board.elite.name=Neuro Processing Unit
-metaitem.circuit.board.elite.tooltip=Neuto CPU
-metaitem.credit.darmstadtium.name=Neutronium Credit
 
-metaitem.rubber_drop.name=Sticky Resin
-
-tile.metal_casing.primitive_bricks.name=Firebricks
-gregtech.machine.primitive_blast_furnace.bronze.tooltip=Structure: 3x3x4 (WxLxH) The entire structure is made out of Firebricks (32 in total)./nFirst Layer is a 3x3 square./nSecond, third, and fourth layers are hollow, without the middle block./nThis block goes on the middle of any side in the second layer./nThe sides of Blast Furnaces can be shared, if the side does not have a controller./n
-
+## Crates and Drums
 gtadditions.machine.drum.wood.name=Wooden Barrel
 gtadditions.machine.drum.bronze.name=Bronze Drum
 gtadditions.machine.drum.steel.name=Steel Drum
@@ -699,38 +498,10 @@ gtadditions.machine.crate.stainless_steel.name=Stainless Steel Crate
 gtadditions.machine.crate.titanium.name=Titanium Crate
 gtadditions.machine.crate.tungstensteel.name=Tungstensteel Crate
 
-fluid.tile.water=Water
-fluid.tile.lava=Lava
 
-gregtech.machine.assembler.iv.name=Assembler IV
-gregtech.machine.autoclave.iv.name=Autoclave IV
-gregtech.machine.laser_engraver.iv.name=Laser Engraver IV
+## Forestry Integration
 
-gtadditions.machine.bundler.lv.name=Basic Bundler
-gtadditions.machine.bundler.mv.name=Advanced Bundler
-gtadditions.machine.bundler.hv.name=Advanced Bundler II
-gtadditions.machine.bundler.ev.name=Advanced Bundler III
-gtadditions.machine.bundler.iv.name=Advanced Bundler IV
-gtadditions.machine.bundler.luv.name=Elite Bundler
-gtadditions.machine.bundler.luv.tooltip=Lapinotron 3000
-gtadditions.machine.bundler.zpm.name=Elite Bundler II
-gtadditions.machine.bundler.zpm.tooltip=Lapinotron 6000
-gtadditions.machine.bundler.uv.name=Elite Bundler III
-gtadditions.machine.bundler.uv.tooltip=Lapinotron 9000
-
-metaitem.plank.jungle.name=Jungle Plank
-metaitem.plank.acacia.name=Acacia Plank
-metaitem.plank.darkoak.name=Dark Oak Plank
-metaitem.plank.birch.name=Birch Plank
-metaitem.plank.spruce.name=Spruce Plank
-metaitem.plank.oak.name=Oak Plank
-metaitem.compressed.coke.clay.name=Compressed Coke Clay
-metaitem.schematic.dust.name=Schematic (Dust)
-metaitem.schematic.3by3.name=Schematic (3x3)
-metaitem.schematic.2by2.name=Schematic (2x2)
-metaitem.schematic.name=Blank Schematic
-metaitem.circuit.wetware_super_computer.name=Wetware Supercomputer
-
+# Combs
 item.gtadditions:comb.lignite.name=Lignite Comb
 item.gtadditions:comb.coal.name=Coal Comb
 item.gtadditions:comb.rubbery.name=Sticky Comb
@@ -764,38 +535,30 @@ item.gtadditions:comb.quantaria.name=Quantaria Comb
 item.gtadditions:comb.urania.name=Urania Comb
 item.gtadditions:comb.plutonium.name=Plutonium Comb
 item.gtadditions:comb.stargatium.name=Stargatium Comb
+
+# Bees
 for.bees.species.slime=Slime
 for.bees.species.lignite=Lignite
 for.bees.species.rubber=Rubbery
-for.bees.species.coal=Coal
-for.bees.species.oill=Oil
-for.bees.species.redstone=Redstone
-for.bees.species.lapis=Lapis
-for.bees.species.certus=Certus
-for.bees.species.ruby=Ruby
-for.bees.species.sapphire=Sapphire
-for.bees.species.diamond=Diamond
-for.bees.species.olivine=Olivine
-for.bees.species.emerald=Emerald
-for.bees.species.copper=Copper
-for.bees.species.tin=Tin
-for.bees.species.lead=Lead
-for.bees.species.iron=Iron
-for.bees.species.steel=Steel
-for.bees.species.nickel=Nickel
-for.bees.species.zinc=Zinc
-for.bees.species.silver=Silver
-for.bees.species.gold=Gold
-for.bees.species.aluminium=Aluminium
-for.bees.species.titanium=Titanium
-for.bees.species.chrome=Chrome
-for.bees.species.manganese=Manganese
-for.bees.species.tungsten=Tungsten
-for.bees.species.platinum=Platinum
-for.bees.species.iridium=Iridium
-for.bees.species.uranium=Uranium
-for.bees.species.plutonium=Plutonium
-for.bees.species.naquadah=Naquadah
+
+# Electrodes
+metaitem.electrode.apatite.name=Apatine Electrode
+metaitem.electrode.blaze.name=Blazing Electrode
+metaitem.electrode.bronze.name=Bronze Electrode
+metaitem.electrode.copper.name=Copper Electrode
+metaitem.electrode.diamond.name=Diamantine Electrode
+metaitem.electrode.emerald.name=Emerald Electrode
+metaitem.electrode.ender.name=Ender Electrode
+metaitem.electrode.gold.name=Golden Electrode
+metaitem.electrode.iron.name=Iron Electrode
+metaitem.electrode.lapis.name=Lapis Electrode
+metaitem.electrode.obsidian.name=Obsidian Electrode
+metaitem.electrode.orchid.name=Orchid Electrode
+metaitem.electrode.rubber.name=Rubberised Electrode
+metaitem.electrode.tin.name=Tin Electrode
+
+
+## Tinker's Construct Integration
 
 material.aluminium.name=Aluminium
 material.chrome.name=Chrome

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -36,6 +36,7 @@ metaitem.circuit.basic.tooltip=A Basic Circuit
 metaitem.circuit.advanced.tooltip=A Good Circuit
 metaitem.circuit.wetware_mainframe.tooltip=An Infinite Circuit
 metaitem.circuit.vacuum_tube.tooltip=A Very Simple Circuit
+metaitem.circuit.advanced_parts.tooltip=A Basic Circuit
 
 # Item Tooltips
 metaitem.compressed.fireclay.tooltip=Brick-Shaped

--- a/src/main/resources/assets/gtadditions/lang/ru_ru.lang
+++ b/src/main/resources/assets/gtadditions/lang/ru_ru.lang
@@ -33,6 +33,7 @@ metaitem.wafer.naquadah.tooltip=Raw Circuit
 
 # Circuit Tooltips
 metaitem.circuit.basic.tooltip=Основная схема
+metaitem.circuit.good.tooltip=A Good Circuit
 metaitem.circuit.advanced.tooltip=Хорошая схема
 metaitem.circuit.wetware_mainframe.tooltip=An Infinite Circuit
 metaitem.circuit.vacuum_tube.tooltip=A Very Simple Circuit

--- a/src/main/resources/assets/gtadditions/lang/ru_ru.lang
+++ b/src/main/resources/assets/gtadditions/lang/ru_ru.lang
@@ -42,7 +42,7 @@ metaitem.circuit.advanced_parts.tooltip=Основная схема
 # Item Tooltips
 metaitem.compressed.fireclay.tooltip=Brick-Shaped
 metaitem.stemcells.tooltip=Raw Intelligence
-metaitem.component.glass.fiber.tooltip=B(SiO2)7
+metaitem.component.glass.fiber.tooltip=B(SiO₂)₇
 metaitem.component.petri.dish.tooltip=For Cultivating Cells
 
 

--- a/src/main/resources/assets/gtadditions/lang/ru_ru.lang
+++ b/src/main/resources/assets/gtadditions/lang/ru_ru.lang
@@ -1,192 +1,147 @@
-metaitem.assembly.normal.name=Сборщик процессоров
-metaitem.assembly.normal.tooltip=Усовершенствованная схема
-metaitem.assembly.nano.name=Сборщик нанопроцессоров
-metaitem.assembly.nano.tooltip=Экстремальная схема
-metaitem.assembly.wetware.name=Сборщик органических-процессоров
-metaitem.assembly.wetware.tooltip=Конечная схема
-metaitem.board.coated.name=Прорезиненая подложка
+## Shadows of Greg ru_ru lang file
+
+## Item Tooltips
+
+# Board Tooltips
 metaitem.board.coated.tooltip=Примитвная база для схемы
-metaitem.board.epoxy.name=Эпоксидная подложка
 metaitem.board.epoxy.tooltip=Улучшеная база для схемы
-metaitem.board.fiber-reinforced.name=Армированная печатная плата
-metaitem.board.fiber-reinforced.tooltip=Упрочненная база для схемы
-metaitem.board.multilayer.fiber-reinforced.name=Многослойная армированная печатная плата
-metaitem.board.multilayer.fiber-reinforced.tooltip=Элитная база для схемы
-metaitem.board.phenolic.name=Профеноленая подложка
+metaitem.board.fiber_reinforced.tooltip=An Extreme Board
+metaitem.board.multilayer.fiber_reinforced.tooltip=An Elite Board
 metaitem.board.phenolic.tooltip=Хорошая база для схемы
-metaitem.board.plastic.name=Пластиковая подложка
 metaitem.board.plastic.tooltip=Хорошая база для схемы
-metaitem.board.wetware.name=Питательная подложка
 metaitem.board.wetware.tooltip=The Board That Keeps Life
-metaitem.boule.silicon.name=Кремниевый монокристалл
-metaitem.boule.silicon.tooltip=Raw Circuit
-metaitem.boule.glowstone.name=Светокамневый монокристалл
-metaitem.boule.glowstone.tooltip=Raw Circuit
-metaitem.boule.naquadah.name=Наквадаховый монокристалл
-metaitem.boule.naquadah.tooltip=Raw Circuit
-metaitem.brick.coke.name=Кирпич коксовой печи
-metaitem.brick.fireclay.name=Кирпич из шамотной глины
-metaitem.circuit.advanced.regular.name=Улучшенный Circuit
-metaitem.circuit.advanced.regular.tooltip=An Advanced Circuit
-metaitem.circuit.good.regular.name=Good Integrated Circuit
-metaitem.circuit.good.regular.tooltip=A Good Circuit
-metaitem.circuit.basic.regular.name=Basic Circuit
-metaitem.circuit.basic.regular.tooltip=A Basic Circuit
-metaitem.circuit.vacuum_tube.name=Электровакуумная лампа
-metaitem.circuit.vacuum.tube.tooltip=A Very Simple Circuit
-metaitem.component.diode.name=Диод
+
+# Electronic Components Tooltips
 metaitem.component.diode.tooltip=Basic Электронный компонент
-metaitem.component.capacitor.name=Конденсатор
 metaitem.component.capacitor.tooltip=Электронный компонент
-metaitem.component.glass.fiber.name=Стекловолокно
-metaitem.component.glass.fiber.tooltip=B(SiO2)7
-metaitem.component.glass.tube.name=Стеклянная трубка
-metaitem.component.petri.dish.name=Petri Dish
-metaitem.component.petri.dish.tooltip=For Cultivating Cells
-metaitem.component.resistor.name=Резистор
 metaitem.component.resistor.tooltip=Basic Электронный компонент
-metaitem.component.small_coil.name=Маленькая катушка
-metaitem.component.small.coil.tooltip=Basic Электронный компонент
-metaitem.component.smd.capacitor.name=SMD Конденсатор
+metaitem.component.small_coil.tooltip=Basic Electronic Component
 metaitem.component.smd.capacitor.tooltip=Электронный компонент
-metaitem.component.smd.diode.name=SMD Диод
 metaitem.component.smd.diode.tooltip=Электронный компонент
-metaitem.component.smd.resistor.name=SMD Резистор
 metaitem.component.smd.resistor.tooltip=Электронный компонент
-metaitem.component.smd.transistor.name=SMD Транзистор
 metaitem.component.smd.transistor.tooltip=Электронный компонент
-metaitem.component.transistor.name=Транзистор
 metaitem.component.transistor.tooltip=Basic Электронный компонент
-metaitem.compressed.clay.name=Сжатая глина
-metaitem.compressed.fireclay.name=Сжатая шамотная глина
-metaitem.compressed.fireclay.tooltip=Brick-Shaped
-metaitem.computer.crystal.name=Ultimate Crystalcomputer
-metaitem.computer.crystal.tooltip=An Ultimate Circuit
-metaitem.computer.nano.name=Elite Nanocomputer
-metaitem.computer.nano.tooltip=An Elite Circuit
-metaitem.computer.quantum.name=Master Quantumcomputer
-metaitem.computer.quantum.tooltip=A Master Circuit
-metaitem.computer.wetware.name=Wetware Supercomputer
-metaitem.computer.wetware.tooltip=A Super Circuit
-metaitem.mainframe.crystal.name=Crystalprocessor Mainframe
-metaitem.mainframe.crystal.tooltip=A Super Circuit
-metaitem.mainframe.nano.name=Nanoprocessor Mainframe
-metaitem.mainframe.nano.tooltip=A Master Circuit
-metaitem.mainframe.normal.name=Mainframe
-metaitem.mainframe.normal.tooltip=An Elite Circuit
-metaitem.mainframe.quantum.name=Quantumprocessor Mainframe
-metaitem.mainframe.quantum.tooltip=An Ultimate Circuit
-metaitem.mainframe.wetware.name=Wetware Mainframe
-metaitem.mainframe.wetware.tooltip=An Infinite Circuit
-metaitem.plate.asoc.name=ASoC
-metaitem.plate.asoc.tooltip=Улучшенный System on a Chip
-metaitem.plate.circuit.name=Integrated Logic Circuit
-metaitem.plate.circuit.tooltip=Integrated Circuit
-metaitem.plate.cpu.name=Central Processing Unit
-metaitem.plate.cpu.tooltip=Integrated Circuit
-metaitem.plate.hpic.name=High Power IC
-metaitem.plate.hpic.tooltip=High Power Circuit
-metaitem.plate.nand.name=NAND Memory Chip
-metaitem.plate.nand.tooltip=Integrated Circuit
-metaitem.plate.nanocpu.name=Nanocomponent Central Processing Unit
-metaitem.plate.nanocpu.tooltip=Power Circuit
-metaitem.plate.nor.name=NOR Memory Chip
-metaitem.plate.nor.tooltip=Integrated Circuit
-metaitem.plate.pic.name=Power IC
-metaitem.plate.pic.tooltip=Power Circuit
-metaitem.plate.qbit.name=QBit Processing Unit
-metaitem.plate.qbit.tooltip=Quantum CPU
-metaitem.plate.ram.name=Random Access Memory Chip
-metaitem.plate.ram.tooltip=Integrated Circuit
-metaitem.plate.soc.name=SoC
-metaitem.plate.soc.tooltip=System on a Chip
-metaitem.processor.crystal.name=Crystalprocessor
-metaitem.processor.crystal.tooltip=An Elite Circuit
-metaitem.processor.nano.name=Nanoprocessor
-metaitem.processor.nano.tooltip=An Advanced Circuit
-metaitem.processor.quantum.name=Quantumprocessor
-metaitem.processor.quantum.tooltip=An Extreme Circuit
-metaitem.processor.wetware.name=Wetwareprocessor
-metaitem.processor.wetware.tooltip=A Master Circuit
-metaitem.wafer.asoc.name=ASoC Wafer
-metaitem.wafer.asoc.tooltip=Raw Circuit
-metaitem.wafer.circuit.name=Integrated Logic Circuit (Wafer)
-metaitem.wafer.circuit.tooltip=Raw Circuit
-metaitem.wafer.cpu.name=Central Processing Unit (wafer)
-metaitem.wafer.cpu.tooltip=Raw Circuit
-metaitem.wafer.glowstone.name=Светокамневый лист
-metaitem.wafer.glowstone.tooltip=Raw Circuit
-metaitem.wafer.hpic.name=HPIC Wafer
-metaitem.wafer.hpic.tooltip=Raw Circuit
-metaitem.wafer.naquadah.name=Наквадаховый лист
-metaitem.wafer.naquadah.tooltip=Raw Circuit
-metaitem.wafer.nand.name=NAND Memory Chip (Wafer)
-metaitem.wafer.nand.tooltip=Raw Circuit
-metaitem.wafer.nanocpu.name=NanoCPU Wafer
-metaitem.wafer.nanocpu.tooltip=Raw Circuit
-metaitem.wafer.nor.name=NOR Memory Chip (wafer)
-metaitem.wafer.nor.tooltip=Raw Circuit
-metaitem.wafer.pic.name=PIC Wafer
-metaitem.wafer.pic.tooltip=Raw Circuit
-metaitem.wafer.qbit.name=QBit Wafer
-metaitem.wafer.qbit.tooltip=Raw Circuit
-metaitem.wafer.ram.name=Random Acccess Memory Chip (Wafer)
-metaitem.wafer.ram.tooltip=Raw Circuit
-metaitem.wafer.silicon.name=Силиконовый лист
+
+# Wafers and Components Tooltips
+metaitem.boule.silicon.tooltip=Raw Circuit
+metaitem.boule.glowstone.tooltip=Raw Circuit
+metaitem.boule.naquadah.tooltip=Raw Circuit
+metaitem.plate.qbit_central_processing_unit.tooltip=Quantum CPU
 metaitem.wafer.silicon.tooltip=Raw Circuit
-metaitem.wafer.soc.name=SoC Wafer
-metaitem.wafer.soc.tooltip=Raw Circuit
-metaitem.form.acacia.name=Acacia Brick Form
-metaitem.form.birch.name=Birch Brick Form
-metaitem.form.darkoak.name=Dark Oak Brick Form
-metaitem.form.jungle.name=Jungle Brick Form
-metaitem.form.oak.name=Oak Brick Form
-metaitem.form.spruce.name=Spruce Brick Form
-metaitem.carbon.fibers.name=Сырые углеродные волокна
-metaitem.plate.mixed.metal.name=Mixed Metal plate
-metaitem.plate.advanced_alloy.name=Усиленный сплав (Пластина)
-metaitem.crystal.raw.name=Raw Crystal Chip
-metaitem.crystal.raw.tooltip=Raw Crystal Processor
-metaitem.crystal.cpu.name=Crystal Processing Unit
-metaitem.crystal.cpu.tooltip=Crystal CPU
-metaitem.crystal.soc.name=Crystal SoC
-metaitem.crystal.soc.tooltip=Crystal System on a Chip
-metaitem.stemcells.name=Stemcells
+metaitem.wafer.glowstone.tooltip=Raw Circuit
+metaitem.wafer.naquadah.tooltip=Raw Circuit
+
+# Circuit Tooltips
+metaitem.circuit.basic.tooltip=Основная схема
+metaitem.circuit.advanced.tooltip=Хорошая схема
+metaitem.circuit.wetware_mainframe.tooltip=An Infinite Circuit
+metaitem.circuit.vacuum_tube.tooltip=A Very Simple Circuit
+metaitem.circuit.advanced_parts.tooltip=Основная схема
+
+# Item Tooltips
+metaitem.compressed.fireclay.tooltip=Brick-Shaped
 metaitem.stemcells.tooltip=Raw Intelligence
-metaitem.crystal.lapotron.name=Lapotron Crystal
-metaitem.plate.iridium_alloy.name=Иридиевый сплав (Пластина)
-metaitem.plate.iridium.alloy.uncompressed.name=Uncompressed Iridium Alloy Plate
-metaitem.neutron_reflector.name=Нейтронный отражатель
-metaitem.processor.neuro.name=Neuro Processing Unit
+metaitem.component.glass.fiber.tooltip=B(SiO2)7
+metaitem.component.petri.dish.tooltip=For Cultivating Cells
 
-metaitem.electrode.apatite.name=Apatine Electrode
-metaitem.electrode.blaze.name=Blazing Electrode
-metaitem.electrode.bronze.name=Bronze Electrode
-metaitem.electrode.copper.name=Copper Electrode
-metaitem.electrode.diamond.name=Diamantine Electrode
-metaitem.electrode.emerald.name=Emerald Electrode
-metaitem.electrode.ender.name=Ender Electrode
-metaitem.electrode.gold.name=Golden Electrode
-metaitem.electrode.iron.name=Iron Electrode
-metaitem.electrode.lapis.name=Lapis Electrode
-metaitem.electrode.obsidian.name=Obsidian Electrode
-metaitem.electrode.orchid.name=Orchid Electrode
-metaitem.electrode.rubber.name=Rubberised Electrode
-metaitem.electrode.tin.name=Tin Electrode
 
+## Item Names/Renames
+
+# Renaming Boules
+metaitem.boule.silicon.name=Кремниевый монокристалл
+metaitem.boule.glowstone.name=Светокамневый монокристалл
+metaitem.boule.naquadah.name=Наквадаховый монокристалл
+
+# Naming Multiblock Parts
+tile.ga_multiblock_casing.tungstensteel_gearbox_casing.name=Assembly Line Casing
+tile.ga_transparent_casing.reinforced_glass.name=Reinforced Glass
+
+# Naming Batteries
 metaitem.energy.module.name=Energy Module
 metaitem.energy.cluster.name=Energy Cluster
 metaitem.max.battery.name=MAX Battery
 
-gtadditions.machine.circuit_assembler.lv.name=Basic Circuit Assembling Machine
-gtadditions.machine.circuit_assembler.mv.name=Улучшенный Circuit Assembling Machine
-gtadditions.machine.circuit_assembler.hv.name=Улучшенный Circuit Assembling Machine II
-gtadditions.machine.circuit_assembler.ev.name=Улучшенный Circuit Assembling Machine III
-gtadditions.machine.circuit_assembler.iv.name=Улучшенный Circuit Assembling Machine IV
-gtadditions.machine.circuit_assembler.luv.name=Улучшенный Circuit Assembling Machine V
-gtadditions.machine.circuit_assembler.zpm.name=Улучшенный Circuit Assembling Machine VI
-gtadditions.machine.circuit_assembler.uv.name=Улучшенный Circuit Assembling Machine VII
+# Naming Items
+metaitem.component.petri.dish.name=Petri Dish
+metaitem.compressed.clay.name=Сжатая глина
+metaitem.stemcells.name=Stem cells
+metaitem.credit.darmstadtium.name=Дармштадтиевый кредит
+metaitem.rubber_drop.name=Резина
+metaitem.component.glass.fiber.name=Стекловолокно
+metaitem.compressed.coke.clay.name=Compressed Coke Clay
 
+# Renaming Circuits
+metaitem.circuit.integrated.name=Интегральная схема
+metaitem.circuit.advanced.name=Улучшенный Circuit
+metaitem.circuit.crystal_processor.name=Crystal Processor
+metaitem.circuit.nano_processor.name=Nano Processor
+metaitem.circuit.quantum_processor.name=Quantum Processor
+metaitem.processor.neuro.name=Neuro Processing Unit
+
+# Naming Schematics
+metaitem.schematic.dust.name=Schematic (Dust)
+metaitem.schematic.3by3.name=Schematic (3x3)
+metaitem.schematic.2by2.name=Schematic (2x2)
+metaitem.schematic.name=Blank Schematic
+
+# Renaming Rubber Components
+item.epoxid.ingot=Эпоксидная плитка
+item.epoxid.dustTiny=Крошечная кучка эпоксидных волокон
+item.epoxid.dustSmall=Маленькая кучка эпоксидных волокон
+item.epoxid.dust=Эпоксидные волокна
+item.epoxid.nugget=Эпоксидный осколок
+item.epoxid.plate=Эпоксидный лист
+item.epoxid.foil=Тонкий эпоксидный лист
+item.reinforced_epoxy_resin.ingot=Fiber-Reinforced Epoxy Resin Bar
+item.reinforced_epoxy_resin.dustTiny=Tiny Pile of Fiber-Reinforced Epoxy Resin Pulp
+item.reinforced_epoxy_resin.dustSmall=Small Pile of Fiber-Reinforced Epoxy Resin Pulp
+item.reinforced_epoxy_resin.dust=Fiber-Reinforced Epoxy Resin Pulp
+item.reinforced_epoxy_resin.nugget=Fiber-Reinforced Epoxy Resin Chip
+item.reinforced_epoxy_resin.plate=Fiber-Reinforced Epoxy Resin Sheet
+item.borosilicate_glass.ingot=Borosilicate Glass Bar
+item.borosilicate_glass.dustTiny=Tiny Pile of Borosilicate Glass Pulp
+item.borosilicate_glass.dustSmall=Small Pile of Borosilicate Glass Pulp
+item.borosilicate_glass.dust=Borosilicate Glass Pulp
+item.borosilicate_glass.nugget=Borosilicate Glass Chip
+item.polyvinyl_chloride.ingot=Polyvinyl Chloride Bar
+item.polyvinyl_chloride.dustTiny=Tiny Pile of Polyvinyl Chloride Pulp
+item.polyvinyl_chloride.dustSmall=Small Pile of Polyvinyl Chloride Pulp
+item.polyvinyl_chloride.dust=Polyvinyl Chloride Pulp
+item.polyvinyl_chloride.nugget=Polyvinyl Chloride Chip
+item.polyvinyl_chloride.plateDense=Dense Polyvinyl Chloride Sheet
+item.polyvinyl_chloride.plate=Polyvinyl Chloride Sheet
+item.polyvinyl_chloride.foil=Thin Polyvinyl Chloride Sheet
+item.silicon_rubber.ingot=Silicone Rubber Bar
+item.silicon_rubber.dustTiny=Tiny Pile of Silicone Rubber Pulp
+item.silicon_rubber.dustSmall=Small Pile of Silicone Rubber Pulp
+item.silicon_rubber.dust=Silicone Rubber Pulp
+item.silicon_rubber.nugget=Silicone Rubber Chip
+item.silicon_rubber.plate=Silicone Rubber Sheet
+item.silicon_rubber.foil=Thin Silicone Rubber Sheet
+item.polystyrene.ingot=Polystyrene Bar
+item.polystyrene.dustTiny=Tiny Pile of Polystyrene Pulp
+item.polystyrene.dustSmall=Small Pile of Polystyrene Pulp
+item.polystyrene.dust=Polystyrene Pulp
+item.polystyrene.nugget=Polystyrene Chip
+item.polystyrene.plate=Polystyrene Sheet
+item.polystyrene.foil=Thin Polystyrene Sheet
+item.styrene_butadiene_rubber.ingot=Styrene-Butadiene Rubber Bar
+item.styrene_butadiene_rubber.dustTiny=Tiny Pile of Styrene-Butadiene Rubber Pulp
+item.styrene_butadiene_rubber.dustSmall=Small Pile of Styrene-Butadiene Rubber Pulp
+item.styrene_butadiene_rubber.dust=Styrene-Butadiene Rubber Pulp
+item.styrene_butadiene_rubber.nugget=Styrene-Butadiene Rubber Chip
+item.styrene_butadiene_rubber.plate=Styrene-Butadiene Rubber Sheet
+
+# Renaming Meat parts
+item.meat.dustTiny=Tiny Pile of Mince Meat
+item.meat.dustSmall=Small Pile of Mince Meat
+item.meat.dust=Mince Meat
+
+
+## Higher Tier Machines
+
+# Cluster Mill
+recipemap.cluster_mill.name=Cluster Mill
 gtadditions.machine.cluster_mill.lv.name=Basic Cluster Mill
 gtadditions.machine.cluster_mill.mv.name=Улучшенный Cluster Mill
 gtadditions.machine.cluster_mill.hv.name=Улучшенный Cluster Mill II
@@ -196,216 +151,272 @@ gtadditions.machine.cluster_mill.luv.name=Улучшенный Cluster Mill V
 gtadditions.machine.cluster_mill.zpm.name=Улучшенный Cluster Mill VI
 gtadditions.machine.cluster_mill.uv.name=Улучшенный Cluster Mill VII
 
-gtadditions.machine.electric_furnace.iv.name=Electron Excitement Processor
-gtadditions.machine.electric_furnace.luv.name=Electron Excitement Processor
-gtadditions.machine.electric_furnace.zpm.name=Electron Excitement Processor
-gtadditions.machine.electric_furnace.uv.name=Electron Excitement Processor
+# Electric Furnace
+gtadditions.machine.electric_furnace.iv.name=Advanced Electric Furnace IV
+gtadditions.machine.electric_furnace.luv.name=Elite Electric Furnace
+gtadditions.machine.electric_furnace.zpm.name=Elite Electric Furnace II
+gtadditions.machine.electric_furnace.uv.name=Elite Electric Furnace III
 
-gtadditions.machine.macerator.iv.name=Blend-O-Matic 9001
-gtadditions.machine.macerator.luv.name=Blend-O-Matic 9002
-gtadditions.machine.macerator.zpm.name=Blend-O-Matic 9003
-gtadditions.machine.macerator.uv.name=Blend-O-Matic 9004
+# Macerator
+gtadditions.machine.macerator.iv.name=Universal Pulverizer II
+gtadditions.machine.macerator.iv.tooltip=Blend-O-Matic 9001
+gtadditions.machine.macerator.luv.name=Universal Pulverizer III
+gtadditions.machine.macerator.luv.tooltip=Blend-O-Matic 9002
+gtadditions.machine.macerator.zpm.name=Universal Pulverizer IV
+gtadditions.machine.macerator.zpm.tooltip=Blend-O-Matic 9003
+gtadditions.machine.macerator.uv.name=Universal Pulverizer V
+gtadditions.machine.macerator.uv.tooltip=Blend-O-Matic 9004
 
+# Alloy Smelter
 gtadditions.machine.alloy_smelter.iv.name=Улучшенный Alloy Smelter IV
 gtadditions.machine.alloy_smelter.luv.name=Улучшенный Alloy Smelter V
 gtadditions.machine.alloy_smelter.zpm.name=Улучшенный Alloy Smelter VI
 gtadditions.machine.alloy_smelter.uv.name=Улучшенный Alloy Smelter VII
 
+# Amplifabricator
 gtadditions.machine.amplifab.iv.name=Улучшенный Amplifabricator IV
 gtadditions.machine.amplifab.luv.name=Улучшенный Amplifabricator V
 gtadditions.machine.amplifab.zpm.name=Улучшенный Amplifabricator VI
 gtadditions.machine.amplifab.uv.name=Улучшенный Amplifabricator VII
 
+# Arc Furnace
 gtadditions.machine.arc_furnace.iv.name=Улучшенный Arc Furnace IV
 gtadditions.machine.arc_furnace.luv.name=Улучшенный Arc Furnace V
 gtadditions.machine.arc_furnace.zpm.name=Улучшенный Arc Furnace VI
 gtadditions.machine.arc_furnace.uv.name=Улучшенный Arc Furnace VII
 
-gtadditions.machine.assembler.iv.name=Улучшенный Assembling Machine IV
+# Assembling Machine
+gregtech.machine.assembler.iv.name=Advanced Assembling Machine IV
 gtadditions.machine.assembler.luv.name=Улучшенный Assembling Machine V
 gtadditions.machine.assembler.zpm.name=Улучшенный Assembling Machine VI
 gtadditions.machine.assembler.uv.name=Улучшенный Assembling Machine VII
 
-gtadditions.machine.autoclave.iv.name=Улучшенный Autoclave IV
+# Autoclave
+gregtech.machine.autoclave.iv.name=Advanced Autoclave IV
 gtadditions.machine.autoclave.luv.name=Улучшенный Autoclave V
 gtadditions.machine.autoclave.zpm.name=Улучшенный Autoclave VI
 gtadditions.machine.autoclave.uv.name=Улучшенный Autoclave VII
 
+# Bender
 gtadditions.machine.bender.iv.name=Улучшенный Bending Machine IV
 gtadditions.machine.bender.luv.name=Улучшенный Bending Machine V
 gtadditions.machine.bender.zpm.name=Улучшенный Bending Machine VI
 gtadditions.machine.bender.uv.name=Улучшенный Bending Machine VII
 
+# Brewery
 gtadditions.machine.brewery.iv.name=Улучшенный Brewery IV
 gtadditions.machine.brewery.luv.name=Улучшенный Brewery V
 gtadditions.machine.brewery.zpm.name=Улучшенный Brewery VI
 gtadditions.machine.brewery.uv.name=Улучшенный Brewery VII
 
+# Canner
 gtadditions.machine.canner.iv.name=Улучшенный Canning Machine IV
 gtadditions.machine.canner.luv.name=Улучшенный Canning Machine V
 gtadditions.machine.canner.zpm.name=Улучшенный Canning Machine VI
 gtadditions.machine.canner.uv.name=Улучшенный Canning Machine VII
 
-gregtech.machine.centrifuge.ev.name=Турбо центрифуга II
-gtadditions.machine.centrifuge.iv.name=Molecular Cyclone
-gtadditions.machine.centrifuge.luv.name=Molecular Cyclone
-gtadditions.machine.centrifuge.zpm.name=Molecular Cyclone
-gtadditions.machine.centrifuge.uv.name=Molecular Cyclone
+# Centrifuge
+gtadditions.machine.centrifuge.iv.name=Turbo Centrifuge III
+gtadditions.machine.centrifuge.iv.tooltip=Molecular Cyclone
+gtadditions.machine.centrifuge.luv.name=Turbo Centrifuge IV
+gtadditions.machine.centrifuge.luv.tooltip=Molecular Cyclone
+gtadditions.machine.centrifuge.zpm.name=Turbo Centrifuge V
+gtadditions.machine.centrifuge.zpm.tooltip=Molecular Cyclone
+gtadditions.machine.centrifuge.uv.name=Turbo Centrifuge VI
+gtadditions.machine.centrifuge.uv.tooltip=Molecular Cyclone
 
+# Chemical Bath
 gtadditions.machine.chemical_bath.iv.name=Улучшенный Chemical Bath IV
 gtadditions.machine.chemical_bath.luv.name=Улучшенный Chemical Bath V
 gtadditions.machine.chemical_bath.zpm.name=Улучшенный Chemical Bath VI
 gtadditions.machine.chemical_bath.uv.name=Улучшенный Chemical Bath VII
 
+# Chemical Reactor
 gtadditions.machine.chemical_reactor.iv.name=Улучшенный Chemical Reactor IV
 gtadditions.machine.chemical_reactor.luv.name=Улучшенный Chemical Reactor V
 gtadditions.machine.chemical_reactor.zpm.name=Улучшенный Chemical Reactor VI
 gtadditions.machine.chemical_reactor.uv.name=Улучшенный Chemical Reactor VII
 
+# Compressor
 gregtech.machine.compressor.ev.name=Сингулярный компрессор
 gtadditions.machine.compressor.iv.name=Сингулярный компрессор IV
 gtadditions.machine.compressor.luv.name=Сингулярный компрессор V
 gtadditions.machine.compressor.zpm.name=Сингулярный компрессор VI
 gtadditions.machine.compressor.uv.name=Сингулярный компрессор VII
 
+# Cutter
 gtadditions.machine.cutter.iv.name=Улучшенный Cutting Machine IV
 gtadditions.machine.cutter.luv.name=Улучшенный Cutting Machine V
 gtadditions.machine.cutter.zpm.name=Улучшенный Cutting Machine VI
 gtadditions.machine.cutter.uv.name=Улучшенный Cutting Machine VII
 
+# Distillery
 gtadditions.machine.distillery.iv.name=Улучшенный Distillery IV
 gtadditions.machine.distillery.luv.name=Улучшенный Distillery V
 gtadditions.machine.distillery.zpm.name=Улучшенный Distillery VI
 gtadditions.machine.distillery.uv.name=Улучшенный Distillery VII
 
+# Electrolyzer
 gregtech.machine.electrolyzer.ev.name=Молекулярный электролизер E-4908
-gtadditions.machine.electrolyzer.iv.name=Molecular Disintegrator E-4905
-gtadditions.machine.electrolyzer.luv.name=Molecular Disintegrator E-4906
-gtadditions.machine.electrolyzer.zpm.name=Molecular Disintegrator E-4907
-gtadditions.machine.electrolyzer.uv.name=Molecular Disintegrator E-4908
+gtadditions.machine.electrolyzer.iv.name=Advanced Electrolyzer IV
+gtadditions.machine.electrolyzer.iv.tooltip=Molecular Disintegrator E-4905
+gtadditions.machine.electrolyzer.luv.name=Elite Electrolyzer
+gtadditions.machine.electrolyzer.luv.tooltip=Molecular Disintegrator E-4906
+gtadditions.machine.electrolyzer.zpm.name=Elite Electrolyzer II
+gtadditions.machine.electrolyzer.zpm.tooltip=Molecular Disintegrator E-4907
+gtadditions.machine.electrolyzer.uv.name=Elite Electrolyzer III
+gtadditions.machine.electrolyzer.uv.tooltip=Molecular Disintegrator E-4908
 
+# Electromagnetic Separator
 gtadditions.machine.electromagnetic_separator.iv.name=Улучшенный Electromagnetic Separator IV
 gtadditions.machine.electromagnetic_separator.luv.name=Улучшенный Electromagnetic Separator V
 gtadditions.machine.electromagnetic_separator.zpm.name=Улучшенный Electromagnetic Separator VI
 gtadditions.machine.electromagnetic_separator.uv.name=Улучшенный Electromagnetic Separator VII
 
+# Extractor
 gregtech.machine.extractor.ev.name=Вакуумный экстрактор
-gtadditions.machine.extractor.iv.name=Vacuum Extractor
-gtadditions.machine.extractor.luv.name=Vacuum Extractor
-gtadditions.machine.extractor.zpm.name=Vacuum Extractor
-gtadditions.machine.extractor.uv.name=Vacuum Extractor
+gtadditions.machine.extractor.iv.name=Advanced Extractor IV
+gtadditions.machine.extractor.luv.name=Elite Extractor
+gtadditions.machine.extractor.zpm.name=Elite Extractor II
+gtadditions.machine.extractor.uv.name=Elite Extractor III
 
+# Extruder
 gtadditions.machine.extruder.iv.name=Улучшенный Extruder IV
 gtadditions.machine.extruder.luv.name=Улучшенный Extruder V
 gtadditions.machine.extruder.zpm.name=Улучшенный Extruder VI
 gtadditions.machine.extruder.uv.name=Улучшенный Extruder VII
 
+# Fermenter
 gtadditions.machine.fermenter.iv.name=Улучшенный Fermenter IV
 gtadditions.machine.fermenter.luv.name=Улучшенный Fermenter V
 gtadditions.machine.fermenter.zpm.name=Улучшенный Fermenter VI
 gtadditions.machine.fermenter.uv.name=Улучшенный Fermenter VII
 
+# Fluid Canner
 gtadditions.machine.fluid_canner.iv.name=Instant Fluid Canner
-gtadditions.machine.fluid_canner.luv.name=Instant Fluid Canner
-gtadditions.machine.fluid_canner.zpm.name=Instant Fluid Canner
-gtadditions.machine.fluid_canner.uv.name=Instant Fluid Canner
+gtadditions.machine.fluid_canner.luv.name=Instant Fluid Canner II
+gtadditions.machine.fluid_canner.zpm.name=Instant Fluid Canner III
+gtadditions.machine.fluid_canner.uv.name=Instant Fluid Canner IV
 
+# Fluid Extractor
 gtadditions.machine.fluid_extractor.iv.name=Улучшенный Fluid Extractor IV
 gtadditions.machine.fluid_extractor.luv.name=Улучшенный Fluid Extractor V
 gtadditions.machine.fluid_extractor.zpm.name=Улучшенный Fluid Extractor VI
 gtadditions.machine.fluid_extractor.uv.name=Улучшенный Fluid Extractor VII
 
+# Fluid Heater
 gtadditions.machine.fluid_heater.iv.name=Улучшенный Fluid Heater IV
 gtadditions.machine.fluid_heater.luv.name=Улучшенный Fluid Heater V
 gtadditions.machine.fluid_heater.zpm.name=Улучшенный Fluid Heater VI
 gtadditions.machine.fluid_heater.uv.name=Улучшенный Fluid Heater VII
 
+# Fluid Solidifier
 gtadditions.machine.fluid_solidifier.iv.name=Улучшенный Fluid Solidifier IV
 gtadditions.machine.fluid_solidifier.luv.name=Улучшенный Fluid Solidifier V
 gtadditions.machine.fluid_solidifier.zpm.name=Улучшенный Fluid Solidifier VI
 gtadditions.machine.fluid_solidifier.uv.name=Улучшенный Fluid Solidifier VII
 
+# Forge Hammer
 gtadditions.machine.forge_hammer.iv.name=Улучшенный Forge Hammer IV
 gtadditions.machine.forge_hammer.luv.name=Улучшенный Forge Hammer V
 gtadditions.machine.forge_hammer.zpm.name=Улучшенный Forge Hammer VI
 gtadditions.machine.forge_hammer.uv.name=Улучшенный Forge Hammer VII
 
+# Forming Press
 gtadditions.machine.forming_press.iv.name=Улучшенный Forming Press IV
 gtadditions.machine.forming_press.luv.name=Улучшенный Forming Press V
 gtadditions.machine.forming_press.zpm.name=Улучшенный Forming Press VI
 gtadditions.machine.forming_press.uv.name=Улучшенный Forming Press VII
 
+# Lathe
 gtadditions.machine.lathe.iv.name=Улучшенный Lathe IV
 gtadditions.machine.lathe.luv.name=Улучшенный Lathe V
 gtadditions.machine.lathe.zpm.name=Улучшенный Lathe VI
 gtadditions.machine.lathe.uv.name=Улучшенный Lathe VII
 
+# Microwave
 gtadditions.machine.microwave.iv.name=Улучшенный Microwave IV
 gtadditions.machine.microwave.luv.name=Улучшенный Microwave V
 gtadditions.machine.microwave.zpm.name=Улучшенный Microwave VI
 gtadditions.machine.microwave.uv.name=Улучшенный Microwave VII
 
+# Mixer
 gtadditions.machine.mixer.iv.name=Улучшенный Mixer IV
 gtadditions.machine.mixer.luv.name=Улучшенный Mixer V
 gtadditions.machine.mixer.zpm.name=Улучшенный Mixer VI
 gtadditions.machine.mixer.uv.name=Улучшенный Mixer VII
 
-gtadditions.machine.ore_washer.iv.name=Repurposed Laundry-Washer I-360
-gtadditions.machine.ore_washer.luv.name=Repurposed Laundry-Washer I-720
-gtadditions.machine.ore_washer.zpm.name=Repurposed Laundry-Washer I-1080
-gtadditions.machine.ore_washer.uv.name=Repurposed Laundry-Washer I-1440
+# Ore Washer
+gtadditions.machine.ore_washer.iv.name=Advanced Ore Washing Plant IV
+gtadditions.machine.ore_washer.iv.tooltip=Repurposed Laundry-Washer I-360
+gtadditions.machine.ore_washer.luv.name=Elite Ore Washing Plant
+gtadditions.machine.ore_washer.luv.tooltip=Repurposed Laundry-Washer I-720
+gtadditions.machine.ore_washer.zpm.name=Elite Ore Washing Plant II
+gtadditions.machine.ore_washer.zpm.tooltip=Repurposed Laundry-Washer I-1080
+gtadditions.machine.ore_washer.uv.name=Elite Ore Washing Plant III
+gtadditions.machine.ore_washer.uv.tooltip=Repurposed Laundry-Washer I-1440
 
-gtadditions.machine.packer.iv.name=Boxinator
-gtadditions.machine.packer.luv.name=Boxinator
-gtadditions.machine.packer.zpm.name=Boxinator
-gtadditions.machine.packer.uv.name=Boxinator
+# Packer
+gtadditions.machine.packer.iv.name=Advanced Packager IV
+gtadditions.machine.packer.luv.name=Elite Packager
+gtadditions.machine.packer.zpm.name=Elite Packager II
+gtadditions.machine.packer.uv.name=Elite Packager III
 
-gtadditions.machine.unpacker.iv.name=Unboxinator
-gtadditions.machine.unpacker.luv.name=Unboxinator
-gtadditions.machine.unpacker.zpm.name=Unboxinator
-gtadditions.machine.unpacker.uv.name=Unboxinator
+# Unpacker
+gtadditions.machine.unpacker.iv.name=Advanced Unpackager IV
+gtadditions.machine.unpacker.luv.name=Elite Unpackager
+gtadditions.machine.unpacker.zpm.name=Elite Unpackager II
+gtadditions.machine.unpacker.uv.name=Elite Unpackager III
 
+# Plasma Arc Furnace
 gtadditions.machine.plasma_arc_furnace.iv.name=Улучшенный Plasma Arc Furnace IV
 gtadditions.machine.plasma_arc_furnace.luv.name=Улучшенный Plasma Arc Furnace V
 gtadditions.machine.plasma_arc_furnace.zpm.name=Улучшенный Plasma Arc Furnace VI
 gtadditions.machine.plasma_arc_furnace.uv.name=Улучшенный Plasma Arc Furnace VII
 
+# Polarizer
 gtadditions.machine.polarizer.iv.name=Улучшенный Polarizer IV
 gtadditions.machine.polarizer.luv.name=Улучшенный Polarizer V
 gtadditions.machine.polarizer.zpm.name=Улучшенный Polarizer VI
 gtadditions.machine.polarizer.uv.name=Улучшенный Polarizer VII
 
+# Laser Engraver
 gtadditions.machine.laser_engraver.iv.name=Улучшенный Precision Laser Engraver IV
 gtadditions.machine.laser_engraver.luv.name=Улучшенный Precision Laser Engraver V
 gtadditions.machine.laser_engraver.zpm.name=Улучшенный Precision Laser Engraver VI
 gtadditions.machine.laser_engraver.uv.name=Улучшенный Precision Laser Engraver VII
 
+# Shifter
 gtadditions.machine.sifter.iv.name=Улучшенный Sifting Machine IV
 gtadditions.machine.sifter.luv.name=Улучшенный Sifting Machine V
 gtadditions.machine.sifter.zpm.name=Улучшенный Sifting Machine VI
 gtadditions.machine.sifter.uv.name=Улучшенный Sifting Machine VII
 
-gtadditions.machine.thermal_centrifuge.iv.name=Blaze Sweatshop T-6350
-gtadditions.machine.thermal_centrifuge.luv.name=Blaze Sweatshop T-6360
-gtadditions.machine.thermal_centrifuge.zpm.name=Blaze Sweatshop T-6370
-gtadditions.machine.thermal_centrifuge.uv.name=Blaze Sweatshop T-6380
+# Thermal Centrifuge
+gtadditions.machine.thermal_centrifuge.iv.name=Advanced Thermal Centrifuge IV
+gtadditions.machine.thermal_centrifuge.iv.tooltip=Blaze Sweatshop T-6350
+gtadditions.machine.thermal_centrifuge.luv.name=Elite Thermal Centrifuge
+gtadditions.machine.thermal_centrifuge.luv.tooltip=Blaze Sweatshop T-6360
+gtadditions.machine.thermal_centrifuge.zpm.name=Elite Thermal Centrifuge II
+gtadditions.machine.thermal_centrifuge.zpm.tooltip=Blaze Sweatshop T-6370
+gtadditions.machine.thermal_centrifuge.uv.name=Elite Thermal Centrifuge III
+gtadditions.machine.thermal_centrifuge.uv.tooltip=Blaze Sweatshop T-6380
 
+# Wiremill
 gtadditions.machine.wiremill.iv.name=Улучшенный Wiremill IV
 gtadditions.machine.wiremill.luv.name=Улучшенный Wiremill V
 gtadditions.machine.wiremill.zpm.name=Улучшенный Wiremill VI
 gtadditions.machine.wiremill.uv.name=Улучшенный Wiremill VII
 
-gtadditions.machine.distill_tower.name=[Deprecated] Distillation Tower
-gtadditions.machine.assembly_line.name=Assembly Line
-gtadditions.machine.processing_array.name=Processing Array
-gtadditions.machine.coke_oven.name=[Deprecated] Coke Oven
-gtadditions.machine.cracker_unit.name=[Deprecated] Cracking Unit
-
+# Naquadah Reactor
+recipemap.naquadah_reactor.name=Naquadah Reactor Fuels
 gtadditions.machine.naquadah_reactor.mk1.name=Naquadah Reactor Mk. 1
 gtadditions.machine.naquadah_reactor.mk2.name=Naquadah Reactor Mk. 2
 gtadditions.machine.naquadah_reactor.mk3.name=Naquadah Reactor Mk. 3
 gtadditions.machine.naquadah_reactor.mk4.name=Naquadah Reactor Mk. 4
 
+# Mass Fabricator
+recipemap.mass_fab.name=Mass Fabricator
 gtadditions.machine.mass_fab.lv.name=Basic Mass Fabricator
 gtadditions.machine.mass_fab.mv.name=Улучшенный Mass Fabricator
 gtadditions.machine.mass_fab.hv.name=Улучшенный Mass Fabricator II
@@ -415,276 +426,92 @@ gtadditions.machine.mass_fab.luv.name=Улучшенный Mass Fabricator V
 gtadditions.machine.mass_fab.zpm.name=Улучшенный Mass Fabricator VI
 gtadditions.machine.mass_fab.uv.name=Улучшенный Mass Fabricator VII
 
+# Replicator
 gtadditions.machine.replicator.lv.name=Basic Replicator
+gtadditions.machine.replicator.lv.tooltip=Producing The Purest Of Elements
 gtadditions.machine.replicator.mv.name=Улучшенный Replicator
+gtadditions.machine.replicator.mv.tooltip=Producing The Purest Of Elements
 gtadditions.machine.replicator.hv.name=Улучшенный Replicator II
+gtadditions.machine.replicator.hv.tooltip=Producing The Purest Of Elements
 gtadditions.machine.replicator.ev.name=Улучшенный Replicator III
+gtadditions.machine.replicator.ev.tooltip=Producing The Purest Of Elements
 gtadditions.machine.replicator.iv.name=Улучшенный Replicator IV
+gtadditions.machine.replicator.iv.tooltip=Producing The Purest Of Elements
 gtadditions.machine.replicator.luv.name=Улучшенный Replicator V
+gtadditions.machine.replicator.luv.tooltip=Producing The Purest Of Elements
 gtadditions.machine.replicator.zpm.name=Улучшенный Replicator VI
+gtadditions.machine.replicator.zpm.tooltip=Producing The Purest Of Elements
 gtadditions.machine.replicator.uv.name=Улучшенный Replicator VII
+gtadditions.machine.replicator.uv.tooltip=Producing The Purest Of Elements
 
+# Bundler
+recipemap.bundler.name=Wire Bundling
+gtadditions.machine.bundler.lv.name=Basic Bundler
+gtadditions.machine.bundler.mv.name=Advanced Bundler
+gtadditions.machine.bundler.hv.name=Advanced Bundler II
+gtadditions.machine.bundler.ev.name=Advanced Bundler III
+gtadditions.machine.bundler.iv.name=Advanced Bundler IV
+gtadditions.machine.bundler.luv.name=Elite Bundler
+gtadditions.machine.bundler.luv.tooltip=Lapinotron 3000
+gtadditions.machine.bundler.zpm.name=Elite Bundler II
+gtadditions.machine.bundler.zpm.tooltip=Lapinotron 6000
+gtadditions.machine.bundler.uv.name=Elite Bundler III
+gtadditions.machine.bundler.uv.tooltip=Lapinotron 9000
+
+# Pump
 gtadditions.machine.pump.iv.name=Улучшенный Pump IV
 gtadditions.machine.pump.luv.name=Улучшенный Pump V
 gtadditions.machine.pump.zpm.name=Улучшенный Pump VI
 gtadditions.machine.pump.uv.name=Улучшенный Pump VII
 
+# Air Collector
 gregtech.machine.air_collector.ev.name=Атмосферный коллектор
-gtadditions.machine.air_collector.iv.name=Atmosphere Collector
-gtadditions.machine.air_collector.luv.name=Atmosphere Collector
+gtadditions.machine.air_collector.iv.name=Advanced Air Collector IV
+gtadditions.machine.air_collector.luv.name=Elite Air Collector
 
-gtadditions.machine.replicator.tooltip=Producing The Purest Of Elements
 
+## Multiblocks
+
+# Plasma Turbine
+recipemap.plasma_generator.name=Плазменное турбинное топливо
+
+# Fusion Reactor
 gtadditions.machine.fusion_reactor.luv.name=Компьютер термоядерного реактора Марк 1
 gtadditions.machine.fusion_reactor.zpm.name=Компьютер термоядерного реактора Марк 2
 gtadditions.machine.fusion_reactor.uv.name=Компьютер термоядерного реактора Марк 3
-
-gtadditions.machine.coke_item_bus.name=[Deprecated] Coke Oven Chute
-gtadditions.machine.coke_fluid_hatch.name=[Deprecated] Coke Oven Faucet
-
-tile.ga_multiblock_casing.coke_oven_bricks.name=Coke Oven Bricks
-tile.ga_multiblock_casing.tungstensteel_gearbox_casing.name=Assembly Line Casing
-tile.ga_transparent_casing.reinforced_glass.name=Reinforced Glass
-
-metaitem.tool.bending_cylinder.name=%s Bending Cylinder
-metaitem.tool.bending_cylinder_small.name=Small %s Bending Cylinder
-
-recipemap.cluster_mill.name=Cluster Mill
-recipemap.circuit_assembler.name=Circuit Assembler
-recipemap.coke_oven.name=[Deprecated] Coke Oven
-recipemap.distill_tower.name=[Deprecated] Distillation Tower
-recipemap.assembly_line.name=Assembly Line
-recipemap.processing_array.name=Processing Array
-recipemap.naquadah_reactor.name=Naquadah Reactor Fuels
-recipemap.replicator.name=Репликатор
-recipemap.mass_fab.name=Mass Fabricator
-recipemap.cracker_unit.name=[Deprecated] Cracking Recipes
-recipemap.bundler.name=Wire Bundling
-
-recipemap.plasma_generator.name=Плазменное турбинное топливо
-
-material.brick=Кирпич
-material.fireclay=Шамотная глина
-material.coke=Коксовый уголь
-material.phosphorous_pentoxide=Пятиокись фосфора
-material.phosphoric_acid=Фосфорная кислота
-material.polyvinyl_acetate=Поливинилацетат
-material.phenol=Фенол
-material.bisphenol_a=Бисфенол А
-material.epoxid=Epoxy Resin
-material.reinforced_epoxy_resin=Укрепленная эпоксидная смола
-material.borosilicate_glass=Боросиликатное стекло
-material.polyvinyl_chloride=Поливинил хлорид
-material.vinyl_chloride=Винил хлорид
-material.ethylene=Этилен
-material.charcoal_byproducts=Продукты переработки Древесного угля
-material.benzene=Бензол
-material.wood_gas=Древесный газ
-material.wood_vinegar=Древесный уксус
-material.wood_tar=Древесная смола
-material.sodium_hydroxide=Гидроксид натрия
-material.quicklime=Негашеная известь
-material.acetone=Ацетон
-material.sulfur_trioxide=Триоксид серы
-material.sulfur_dioxide=Дииоксид серы
-material.glycerol=Глицерин
-material.fish_oil=Рыбий жир
-material.methanol=Метанол
-material.carbon_monoxide=Монооксид углерода
-material.nitro_fuel=Цетановый дизель
-material.diluted_sulfuric_acid=Разбавленная серная кислота
-material.sodium_bisulfate=Бисульфат натрия
-material.chloroform=Хлороформ
-material.diluted_hydrochloric_acid=Разбавленная соляная кислота
-material.hypochlorous_acid=Соляная кислота
-material.ammonia=Аммиак
-material.chloramine=Хлорамин
-material.dimethylamine=Диметиламин
-material.dimethylhidrazine=1,1-Диметилгидразин
-material.rocket_fuel=Ракетное топливо
-material.dinitrogen_tetroxide=Тетраоксид диазота
-material.silicon_rubber=Силиконовая резина
-material.polydimethylsiloxane=Полидиметилсилоксан
-material.dimethyldichlorosilane=Диметилдихлорсилана
-material.styrene=Стирол
-material.polystyrene=Полистирол
-material.butadiene=Бутадиен
-material.raw_styrene_butadiene_rubber=Стирол-бутадиеновый каучук
-material.styrene_butadiene_rubber=Стирол-бутадиеновая резина
-material.dichlorobenzene=Дихлорбензол
-material.hydrochloric_acid=Соляная кислота
-material.acetic_acid=Уксусная кислота
-material.fermented_biomass=Ферментированная биомасса
-material.potash=Оксид калийя
-material.soda_ash=Сода
-material.hydrofluoric_acid=Плавиковая кислота
-material.nitric_oxide=Оксид азота
-material.methyl_acetate=Метилацетат
-material.ethenone=Кетен
-material.tetranitromethane=Тетранитрометан
-material.bio_diesel=Биодизель
-material.raw_growth_medium=Сырая Среда Роста
-material.sterilized_growth_medium=Стерилизованная Среда Роста
-material.meat=Мясо
-material.cooked_meat=Приготовленное мясо
-material.vinyl_acetate=Винилацетат
-material.gallium_arsenide=Арсенид галлия
-material.polyphenylene_sulfide=Полифениленсульфид
-material.nickel_sulfate_water_solution=Водный раствор сульфата никеля
-material.blue_vitriol_water_solution=Водный раствор медного купороса
-material.propane=Пропан
-material.propene=Пропен
-material.ethane=Этан
-material.butene=Бутен
-material.butane=Бутан
-material.calcium_acetate=Раствор ацетата кальция
-material.cumene=Кумола
-material.indium_gallium_phosphide=Индий Галлий Фосфид
-material.platinum_group_sludge=Осадок платиновой группы
-material.ferrite_mixture=Ферритовая смесь
-material.nickel_zinc_ferrite=Никель Цинк Феррит
-material.indium_concentrate=Концентрат Индия
-material.lead_zinc_solution=Свинцово-цинковый раствор
-material.tetrafluoroethylene=Тетрафторэтилен
-material.salt_water=Соленая вода
-material.hydrocracked_ethane=Гидрокрекиговый этан
-material.hydrocracked_ethylene=Гидрокрекиговый этилен
-material.hydrocracked_propene=Гидрокрекиговый пропен
-material.hydrocracked_propane=Гидрокрекиговый пропан
-material.hydrocracked_light_fuel=Гидрокрекиговое легкое топливо
-material.hydrocracked_butane=Гидрокрекиговый бутан
-material.hydrocracked_naphtha=Гидрокрекиговая нафта
-material.hydrocracked_heavy_fuel=Гидрокрекиговое тяжелое топливо
-material.hydrocracked_gas=Гидрокрекиговый нефтяной газ
-material.hydrocracked_butene=Гидрокрекиговый бутен
-material.hydrocracked_butadiene=Гидрокрекиговый бутадиен
-material.steamcracked_ethane=Парокрекиговый этан
-material.steamcracked_ethylene=Парокрекиговый этилен
-material.steamcracked_propene=Парокрекиговый пропен
-material.steamcracked_propane=Парокрекиговый пропан
-material.cracked_light_fuel=Парокрекиговое легкое топливо
-material.steamcracked_butane=Парокрекиговый бутан
-material.steamcracked_naphtha=Парокрекиговый нафта
-material.cracked_heavy_fuel=Парокрекиговое тяжелое топливо
-material.steamcracked_gas=Парокрекиговый нефтяной газ
-material.steamcracked_butene=Парокрекиговый бутен
-material.steamcracked_butadiene=Парокрекиговый бутадиен
-material.biogas=Биогаз
-material.chloromethane=Хлорометан
-material.allyl_chloride=Аллилхлорид
-material.isoprene=Изопрен
-material.massicot=Массикот
-material.antimony_trioxide=Триоксид сурьмы
-material.zincite=Цинкит
-material.cobalt_oxide=Оксид кобальта
-material.arsenic_trioxide=Триоксид мышьяка
-material.cupric_oxide=Оксид меди
-material.ferrosilite=Ферросилит
-material.magnesia=Магнезия
-material.ga_sodium_sulfide=Сульфид натрия
-material.neutral_matter=Нейтральная материя
-material.positive_matter=Положительная материя
-material.neutronium=Нейтроний
-material.plasma=Плазменный конфайнмент
-material.lignite_coke=Лигнитовый уголь
-
-item.epoxid.ingot=Эпоксидная плитка
-item.epoxid.dustTiny=Крошечная кучка эпоксидных волокон
-item.epoxid.dustSmall=Маленькая кучка эпоксидных волокон
-item.epoxid.dust=Эпоксидные волокна
-item.epoxid.nugget=Эпоксидный осколок
-item.epoxid.plateDense=Плотный эпоксидный лист
-item.epoxid.plate=Эпоксидный лист
-item.epoxid.foil=Тонкий эпоксидный лист
-item.reinforced_epoxy_resin.ingot=Fiber-Reinforced Epoxy Resin Bar
-item.reinforced_epoxy_resin.dustTiny=Tiny Pile of Fiber-Reinforced Epoxy Resin Pulp
-item.reinforced_epoxy_resin.dustSmall=Small Pile of Fiber-Reinforced Epoxy Resin Pulp
-item.reinforced_epoxy_resin.dust=Fiber-Reinforced Epoxy Resin Pulp
-item.reinforced_epoxy_resin.nugget=Fiber-Reinforced Epoxy Resin Chip
-item.reinforced_epoxy_resin.plateDense=Dense Fiber-Reinforced Epoxy Resin Sheet
-item.reinforced_epoxy_resin.plate=Fiber-Reinforced Epoxy Resin Sheet
-item.reinforced_epoxy_resin.foil=Thin Fiber-Reinforced Epoxy Resin Sheet
-item.borosilicate_glass.ingot=Borosilicate Glass Bar
-item.borosilicate_glass.dustTiny=Tiny Pile of Borosilicate Glass Pulp
-item.borosilicate_glass.dustSmall=Small Pile of Borosilicate Glass Pulp
-item.borosilicate_glass.dust=Borosilicate Glass Pulp
-item.borosilicate_glass.nugget=Borosilicate Glass Chip
-item.borosilicate_glass.plateDense=Dense Borosilicate Glass Sheet
-item.borosilicate_glass.plate=Borosilicate Glass Sheet
-item.borosilicate_glass.foil=Thin Borosilicate Glass Sheet
-item.polyvinyl_chloride.ingot=Polyvinyl Chloride Bar
-item.polyvinyl_chloride.dustTiny=Tiny Pile of Polyvinyl Chloride Pulp
-item.polyvinyl_chloride.dustSmall=Small Pile of Polyvinyl Chloride Pulp
-item.polyvinyl_chloride.dust=Polyvinyl Chloride Pulp
-item.polyvinyl_chloride.nugget=Polyvinyl Chloride Chip
-item.polyvinyl_chloride.plateDense=Dense Polyvinyl Chloride Sheet
-item.polyvinyl_chloride.plate=Polyvinyl Chloride Sheet
-item.polyvinyl_chloride.foil=Thin Polyvinyl Chloride Sheet
-item.silicone_rubber.ingot=Silicone Rubber Bar
-item.silicone_rubber.dustTiny=Tiny Pile of Silicone Rubber Pulp
-item.silicone_rubber.dustSmall=Small Pile of Silicone Rubber Pulp
-item.silicone_rubber.dust=Silicone Rubber Pulp
-item.silicone_rubber.nugget=Silicone Rubber Chip
-item.silicone_rubber.plateDense=Dense Silicone Rubber Sheet
-item.silicone_rubber.plate=Silicone Rubber Sheet
-item.silicone_rubber.foil=Thin Silicone Rubber Sheet
-item.polystyrene.ingot=Polystyrene Bar
-item.polystyrene.dustTiny=Tiny Pile of Polystyrene Pulp
-item.polystyrene.dustSmall=Small Pile of Polystyrene Pulp
-item.polystyrene.dust=Polystyrene Pulp
-item.polystyrene.nugget=Polystyrene Chip
-item.polystyrene.plateDense=Dense Polystyrene Sheet
-item.polystyrene.plate=Polystyrene Sheet
-item.polystyrene.foil=Thin Polystyrene Sheet
-item.styrene_butadiene_rubber.ingot=Styrene-Butadiene Rubber Bar
-item.styrene_butadiene_rubber.dustTiny=Tiny Pile of Styrene-Butadiene Rubber Pulp
-item.styrene_butadiene_rubber.dustSmall=Small Pile of Styrene-Butadiene Rubber Pulp
-item.styrene_butadiene_rubber.dust=Styrene-Butadiene Rubber Pulp
-item.styrene_butadiene_rubber.nugget=Styrene-Butadiene Rubber Chip
-item.styrene_butadiene_rubber.plateDense=Dense Styrene-Butadiene Rubber Sheet
-item.styrene_butadiene_rubber.plate=Styrene-Butadiene Rubber Sheet
-item.styrene_butadiene_rubber.foil=Thin Styrene-Butadiene Rubber Sheet
-item.meat.dustTiny=Tiny Pile of Mince Meat
-item.meat.dustSmall=Small Pile of Mince Meat
-item.meat.dust=Mince Meat
-
-gregtech.multiblock.coke_oven.description=Коксовая печь - это многоблочная структура, используемая для получения кокосового угля и креозота на ранней стадии игры. Не требует топлива и имеет внутренний бак на 32 ведра креозота. Доступ к инвентарю можно получить через люк коксовой печи.
-gregtech.multiblock.assembly_line.description=The Assembly Line is a large multiblock structure consisting of 5 to 16 "slices". In theory, it's large Assembling Machine, used for creating advanced crafting components.
-gregtech.multiblock.processing_array.description=The Processing Array combines up to 16 single block machines in a single multiblock, effectively easing automation. 
-gregtech.multiblock.distill_tower.description=The GA Distillation Tower is a multiblock structure consisting of 2-12 layers. It's used for distilling fluids, but unlike the Distillery, gives you multiple outputs per input, including item outputs. Every layer has a different output.
 gregtech.multiblock.fusion_reactor_mk1.description=Термоядерный реактор Марк 1 - это большая многоблочная структура, используемая для слияния веществ и синтеза более тяжёлых элементов. Марк 1 может использовать входные разъемы уровней LuV, ZPM и UV. Каждый разъём увеличивает внутренний буфер энергии на 10 млн. EU.
 gregtech.multiblock.fusion_reactor_mk2.description=Термоядерный реактор Марк 2 - это большая многоблочная структура, используемая для слияния веществ и синтеза более тяжёлых элементов. Марк 2 может использовать входные разъемы уровней ZPM и UV. Каждый разъём увеличивает внутренний буфер энергии на 20 млн. EU.
 gregtech.multiblock.fusion_reactor_mk3.description=Термоядерный реактор Марк 3 - это большая многоблочная структура, используемая для слияния веществ и синтеза более тяжёлых элементов. Марк 3 может использовать входные разъемы уровня UV. Каждый разъём увеличивает внутренний буфер энергии на 40 млн. EU.
 gregtech.multiblock.fusion_reactor.heat=Теплота: %d
 
+# Processing Array
+recipemap.processing_array.name=Processing Array
+gtadditions.machine.processing_array.name=Processing Array
+gregtech.multiblock.processing_array.description=The Processing Array combines up to 16 single block machines in a single multiblock, effectively easing automation.
+
+# Assembly Line
+recipemap.assembly_line.name=Assembly Line
+gtadditions.machine.assembly_line.name=Assembly Line
+gregtech.multiblock.assembly_line.description=The Assembly Line is a large multiblock structure consisting of 5 to 16 "slices". In theory, it's large Assembling Machine, used for creating advanced crafting components.
+
+
+## Tools
+metaitem.tool.bending_cylinder.name=%s Bending Cylinder
+metaitem.tool.bending_cylinder_small.name=Small %s Bending Cylinder
+
+
+## Materials
 item.material.oreprefix.plateCurved=Изогнутая %s пластина
-item.material.oreprefix.ingotDouble=%s (Двойной слиток)
-item.material.oreprefix.pipeGaSmall=Небольшая труба %s
-item.material.oreprefix.pipeGa=%s труба
-item.material.oreprefix.pipeGaLarge=Большая труба %s
+material.fish_oil=Рыбий жир
+material.meat=Мясо
+material.neutral_matter=Нейтральная материя
+material.positive_matter=Положительная материя
+material.neutronium=Нейтроний
+material.lignite_coke=Лигнитовый уголь
+material.coke=Коксовый уголь
 
-metaitem.circuit.parts.advanced.name=Микропроцессор
-metaitem.circuit.parts.advanced.tooltip=Основная схема
-metaitem.circuit.integrated.name=Интегральная схема
-metaitem.circuit.basic.name=Basic Circuit
-metaitem.circuit.basic.tooltip=Основная схема
-metaitem.circuit.advanced.name=Улучшенный Circuit
-metaitem.circuit.advanced.tooltip=Хорошая схема
-metaitem.circuit.master.name=Crystalprocessor Assembly
-metaitem.circuit.master.tooltip=A Master Circuit
-metaitem.circuit.elite.name=Quantumprocessor Assembly
-metaitem.circuit.elite.tooltip=An Elite Circuit
-metaitem.circuit.data.name=Workstation
-metaitem.circuit.data.tooltip=An Extreme Circuit
-metaitem.circuit.board.elite.name=Neuro Processing Unit
-metaitem.circuit.board.elite.tooltip=Neuto CPU
-metaitem.credit.darmstadtium.name=Дармштадтиевый кредит
 
-metaitem.rubber_drop.name=Резина
-
-tile.metal_casing.primitive_bricks.name=Примитивные кирпич
-gregtech.machine.primitive_blast_furnace.bronze.tooltip=Структура: 3x3x4 (ДxШxВ) Вся структура сделана из примитивных кирпичей (32 в целом)./nПервый слой площадью 3x3./nВторой, третий и четвертый слои являются полыми, без среднего блока./nЭтот блок идет по середине любой стороны во втором слое./nСтороны доменных печей могут быть общими, если на стороне нет контроллера./n
-
+## Crates and Drums
 gtadditions.machine.drum.wood.name=Деревянная бочка
 gtadditions.machine.drum.bronze.name=Бронзовая бочка
 gtadditions.machine.drum.steel.name=Стальная бочка
@@ -699,38 +526,10 @@ gtadditions.machine.crate.stainless_steel.name=Ящик из нержавеющ�
 gtadditions.machine.crate.titanium.name=Титановый ящик
 gtadditions.machine.crate.tungstensteel.name=Ящик из вольфрамовой стали
 
-fluid.tile.water=Вода
-fluid.tile.lava=Лава
 
-gregtech.machine.assembler.iv.name=Assembler IV
-gregtech.machine.autoclave.iv.name=Autoclave IV
-gregtech.machine.laser_engraver.iv.name=Laser Engraver IV
+## Forestry Integration
 
-gtadditions.machine.bundler.lv.name=Basic Bundler
-gtadditions.machine.bundler.mv.name=Advanced Bundler
-gtadditions.machine.bundler.hv.name=Advanced Bundler II
-gtadditions.machine.bundler.ev.name=Advanced Bundler III
-gtadditions.machine.bundler.iv.name=Advanced Bundler IV
-gtadditions.machine.bundler.luv.name=Elite Bundler
-gtadditions.machine.bundler.luv.tooltip=Lapinotron 3000
-gtadditions.machine.bundler.zpm.name=Elite Bundler II
-gtadditions.machine.bundler.zpm.tooltip=Lapinotron 6000
-gtadditions.machine.bundler.uv.name=Elite Bundler III
-gtadditions.machine.bundler.uv.tooltip=Lapinotron 9000
-
-metaitem.plank.jungle.name=Jungle Plank
-metaitem.plank.acacia.name=Acacia Plank
-metaitem.plank.darkoak.name=Dark Oak Plank
-metaitem.plank.birch.name=Birch Plank
-metaitem.plank.spruce.name=Spruce Plank
-metaitem.plank.oak.name=Oak Plank
-metaitem.compressed.coke.clay.name=Compressed Coke Clay
-metaitem.schematic.dust.name=Schematic (Dust)
-metaitem.schematic.3by3.name=Schematic (3x3)
-metaitem.schematic.2by2.name=Schematic (2x2)
-metaitem.schematic.name=Blank Schematic
-metaitem.circuit.wetware_super_computer.name=Wetware Supercomputer
-
+# Combs
 item.gtadditions:comb.lignite.name=Lignite соты
 item.gtadditions:comb.coal.name=Coal соты
 item.gtadditions:comb.rubbery.name=Sticky соты
@@ -764,38 +563,30 @@ item.gtadditions:comb.quantaria.name=Quantaria соты
 item.gtadditions:comb.urania.name=Urania соты
 item.gtadditions:comb.plutonium.name=Plutonium соты
 item.gtadditions:comb.stargatium.name=Stargatium соты
+
+# Bees
 for.bees.species.slime=Слизь
 for.bees.species.lignite=Ллигнит
 for.bees.species.rubber=Резина
-for.bees.species.coal=Каменный уголь
-for.bees.species.oill=Нефть
-for.bees.species.redstone=Редстоун
-for.bees.species.lapis=Лазурит
-for.bees.species.certus=Истинный кварц
-for.bees.species.ruby=Рубин
-for.bees.species.sapphire=Сапфир
-for.bees.species.diamond=Алмаз
-for.bees.species.olivine=Оливин
-for.bees.species.emerald=Изумруд
-for.bees.species.copper=Медь
-for.bees.species.tin=Олово
-for.bees.species.lead=Свинец
-for.bees.species.iron=Железо
-for.bees.species.steel=Сталь
-for.bees.species.nickel=Никель
-for.bees.species.zinc=Цинк
-for.bees.species.silver=Серебро
-for.bees.species.gold=Золото
-for.bees.species.aluminium=Алюминий
-for.bees.species.titanium=Титан
-for.bees.species.chrome=Хром
-for.bees.species.manganese=Марганец
-for.bees.species.tungsten=Вольфрам
-for.bees.species.platinum=Платина
-for.bees.species.iridium=Иридий
-for.bees.species.uranium=Уран
-for.bees.species.plutonium=Плутоний
-for.bees.species.naquadah=Наквадах
+
+# Electrodes
+metaitem.electrode.apatite.name=Apatine Electrode
+metaitem.electrode.blaze.name=Blazing Electrode
+metaitem.electrode.bronze.name=Bronze Electrode
+metaitem.electrode.copper.name=Copper Electrode
+metaitem.electrode.diamond.name=Diamantine Electrode
+metaitem.electrode.emerald.name=Emerald Electrode
+metaitem.electrode.ender.name=Ender Electrode
+metaitem.electrode.gold.name=Golden Electrode
+metaitem.electrode.iron.name=Iron Electrode
+metaitem.electrode.lapis.name=Lapis Electrode
+metaitem.electrode.obsidian.name=Obsidian Electrode
+metaitem.electrode.orchid.name=Orchid Electrode
+metaitem.electrode.rubber.name=Rubberised Electrode
+metaitem.electrode.tin.name=Tin Electrode
+
+
+## Tinker's Construct Integration
 
 material.aluminium.name=Алюминий
 material.chrome.name=Хром
@@ -854,3 +645,73 @@ material.amethyst.name=Аметист
 material.garnet_red.name=Красный гранат
 material.garnet_yellow.name=Желтый гранат
 material.vinteum.name=Винтеум
+
+#Conflicting Names between current SoG localizations and GTCE localizations
+
+#SoG: metaitem.board.fiber_reinforced.name=Армированная печатная плата
+#GTCE: metaitem.board.fiber_reinforced.name=Укрепленная эпоксидная подложка
+
+#SoG: metaitem.board.multilayer.fiber_reinforced.name=Многослойная армированная печатная плата
+#GTCE: metaitem.board.multilayer.fiber_reinforced.name=Многослойная Укрепленная эпоксидная подложка
+
+#SoG: material.diluted_hydrochloric_acid=Разбавленная соляная кислота
+#GTCE: material.diluted_hydrochloric_acid=Разбавленный хлороводород
+
+#SoG: material.hydrochloric_acid=Соляная кислота
+#GTCE: material.hydrochloric_acid=Хлороводород
+
+#SoG: material.hydrocracked_ethane=Гидрокрекиговый этан
+#GTCE: material.hydrocracked_ethane=Гидрокатализированный этан
+
+#SoG: material.hydrocracked_ethylene=Гидрокрекиговый этилен
+#GTCE: material.hydrocracked_ethylene=Гидрокатализированный этилен
+
+#SoG:
+#material.hydrocracked_propene=Гидрокрекиговый пропен
+#material.hydrocracked_propane=Гидрокрекиговый пропан
+#material.hydrocracked_light_fuel=Гидрокрекиговое легкое топливо
+#material.hydrocracked_butane=Гидрокрекиговый бутан
+#material.hydrocracked_naphtha=Гидрокрекиговая нафта
+#material.hydrocracked_heavy_fuel=Гидрокрекиговое тяжелое топливо
+#material.hydrocracked_gas=Гидрокрекиговый нефтяной газ
+#material.hydrocracked_butene=Гидрокрекиговый бутен
+#material.hydrocracked_butadiene=Гидрокрекиговый бутадиен
+#material.steamcracked_ethane=Парокрекиговый этан
+#material.steamcracked_ethylene=Парокрекиговый этилен
+#material.steamcracked_propene=Парокрекиговый пропен
+#material.steamcracked_propane=Парокрекиговый пропан
+#material.cracked_light_fuel=Парокрекиговое легкое топливо
+#material.steamcracked_butane=Парокрекиговый бутан
+#material.steamcracked_naphtha=Парокрекиговый нафта
+#material.cracked_heavy_fuel=Парокрекиговое тяжелое топливо
+#material.steamcracked_gas=Парокрекиговый нефтяной газ
+#material.steamcracked_butene=Парокрекиговый бутен
+#material.steamcracked_butadiene=Парокрекиговый бутадиен
+
+#GTCE:
+#material.hydrocracked_propene=Гидрокатализированный пропен
+#material.hydrocracked_propane=Гидрокатализированный пропан
+#material.hydrocracked_light_fuel=Гидрокатализированное легкое топливо
+#material.hydrocracked_butane=Гидрокатализированный бутан
+#material.hydrocracked_naphtha=Гидрокатализированная нафта
+#material.hydrocracked_heavy_fuel=Гидрокатализированное тяжелое топливо
+#material.hydrocracked_gas=Гидрокатализированный нефтяной газ
+#material.hydrocracked_butene=Гидрокатализированный бутен
+#material.hydrocracked_butadiene=Гидрокатализированный бутадиен
+#material.steamcracked_ethane=Парокатализированный этан
+#material.steamcracked_ethylene=Парокатализированный этилен
+#material.steamcracked_propene=Парокатализированный пропен
+#material.steamcracked_propane=Парокатализированный пропан
+#material.cracked_light_fuel=Парокатализированное легкое топливо
+#material.steamcracked_butane=Парокатализированный бутан
+#material.steamcracked_naphtha=Парокатализированная нафта
+#material.cracked_heavy_fuel=Парокатализированное тяжелое топливо
+#material.steamcracked_gas=Парокатализированный нефтяной газ
+#material.steamcracked_butene=Парокатализированный бутен
+#material.steamcracked_butadiene=Парокатализированный бутадиен
+
+#SoG: metaitem.circuit.advanced.name=Улучшенный Circuit
+#GTCE: metaitem.circuit.advanced.name=Advanced Circuit
+
+#SoG: metaitem.circuit.advanced_parts.name=Микропроцессор
+#GTCE: metaitem.circuit.advanced_parts.name=Advanced Circuit Parts

--- a/src/main/resources/assets/gtadditions/lang/zh_cn.lang
+++ b/src/main/resources/assets/gtadditions/lang/zh_cn.lang
@@ -42,7 +42,7 @@ metaitem.circuit.advanced_parts.tooltip=A Basic Circuit
 # Item Tooltips
 metaitem.compressed.fireclay.tooltip=砖块状
 metaitem.stemcells.tooltip=智慧的原料
-metaitem.component.glass.fiber.tooltip=B(SiO2)7
+metaitem.component.glass.fiber.tooltip=B(SiO₂)₇
 metaitem.component.petri.dish.tooltip=用以培养细胞
 
 

--- a/src/main/resources/assets/gtadditions/lang/zh_cn.lang
+++ b/src/main/resources/assets/gtadditions/lang/zh_cn.lang
@@ -1,424 +1,452 @@
-metaitem.assembly.normal.name=处理器集群
-metaitem.assembly.normal.tooltip=一个进阶电路板
-metaitem.assembly.nano.name=纳米处理器集群
-metaitem.assembly.nano.tooltip=一个高级电路板
-metaitem.assembly.wetware.name=湿件处理器集群
-metaitem.assembly.wetware.tooltip=一个顶级电路板
-metaitem.board.coated.name=覆膜电路基板
+## Shadows of Greg zh_cn lang file
+
+## Item Tooltips
+
+# Board Tooltips
 metaitem.board.coated.tooltip=一个基础基板
-metaitem.board.epoxy.name=环氧树脂基板
 metaitem.board.epoxy.tooltip=一个进阶基板
-metaitem.board.fiber-reinforced.name=纤维强化电路基板
-metaitem.board.fiber-reinforced.tooltip=一个高级基板
-metaitem.board.multilayer.fiber-reinforced.name=多层纤维强化电路基板
-metaitem.board.multilayer.fiber-reinforced.tooltip=一个精英基板
-metaitem.board.phenolic.name=酚醛树脂电路基板
+metaitem.board.fiber_reinforced.tooltip=一个高级基板
+metaitem.board.multilayer.fiber_reinforced.tooltip=一个精英基板
 metaitem.board.phenolic.tooltip=一个不错的电路板基板
-metaitem.board.plastic.name=塑料电路板基板
 metaitem.board.plastic.tooltip=一个不错的电路板基板
-metaitem.board.wetware.name=湿件生物电路基板
 metaitem.board.wetware.tooltip=能够维持生命活力的电路板基板
-metaitem.boule.silicon.name=单晶硅
-metaitem.boule.silicon.tooltip=电路元件
-metaitem.boule.glowstone.name=萤石掺杂的单晶硅
-metaitem.boule.glowstone.tooltip=电路元件
-metaitem.boule.naquadah.name=硅岩掺杂的单晶硅
-metaitem.boule.naquadah.tooltip=电路元件
-metaitem.brick.coke.name=焦炉砖
-metaitem.brick.fireclay.name=耐火砖
-metaitem.circuit.advanced.regular.name=进阶电路板
-metaitem.circuit.advanced.regular.tooltip=一个进阶电路板
-metaitem.circuit.good.regular.name=不错的集成电路
-metaitem.circuit.good.regular.tooltip=一个不错的电路板
-metaitem.circuit.basic.regular.name=基础电路板
-metaitem.circuit.basic.regular.tooltip=一个基础的电路板
-metaitem.circuit.vacuum.tube.name=真空管
-metaitem.circuit.vacuum.tube.tooltip=一个极其简易的电路板
-metaitem.component.diode.name=二极管
+
+# Electronic Components Tooltips
 metaitem.component.diode.tooltip=基础电子元件
-metaitem.component.capacitor.name=电容
 metaitem.component.capacitor.tooltip=电子元件
-metaitem.component.glass.fiber.name=玻璃纤维
-metaitem.component.glass.fiber.tooltip=B(SiO2)7
-metaitem.component.glass.tube.name=玻璃管
-metaitem.component.petri.dish.name=培养皿
-metaitem.component.petri.dish.tooltip=用以培养细胞
-metaitem.component.resistor.name=电阻
 metaitem.component.resistor.tooltip=基础电子元件
-metaitem.component.small.coil.name=小型线圈
-metaitem.component.small.coil.tooltip=基础电子元件
-metaitem.component.smd.capacitor.name=贴片电容
+metaitem.component.small_coil.tooltip=基础电子元件
 metaitem.component.smd.capacitor.tooltip=电子元件
-metaitem.component.smd.diode.name=贴片二极管
 metaitem.component.smd.diode.tooltip=电子元件
-metaitem.component.smd.resistor.name=贴片电阻
 metaitem.component.smd.resistor.tooltip=电子元件
-metaitem.component.smd.transistor.name=贴片晶体管
 metaitem.component.smd.transistor.tooltip=电子元件
-metaitem.component.transistor.name=晶体管
 metaitem.component.transistor.tooltip=基础电子元件
-metaitem.compressed.clay.name=砖坯
-metaitem.compressed.coke.clay.name=焦炉砖坯
-metaitem.compressed.fireclay.name=耐火砖坯
-metaitem.compressed.fireclay.tooltip=砖块状
-metaitem.computer.crystal.name=终极晶体电脑
-metaitem.computer.crystal.tooltip=一个顶级电路板
-metaitem.computer.nano.name=精英纳米电脑
-metaitem.computer.nano.tooltip=一个精英电路板
-metaitem.computer.quantum.name=大型量子电脑
-metaitem.computer.quantum.tooltip=一个大师级电路板
-metaitem.computer.wetware.name=湿件处理器超级电脑
-metaitem.computer.wetware.tooltip=一个超级电路板
-metaitem.mainframe.crystal.name=晶体处理器主机
-metaitem.mainframe.crystal.tooltip=一个超级电路板
-metaitem.mainframe.nano.name=纳米处理器主机
-metaitem.mainframe.nano.tooltip=一个大师级电路板
-metaitem.mainframe.normal.name=处理器主机
-metaitem.mainframe.normal.tooltip=一个精英电路板
-metaitem.mainframe.quantum.name=量子处理器主机
-metaitem.mainframe.quantum.tooltip=一个顶级电路板
-metaitem.mainframe.wetware.name=湿件主机
-metaitem.mainframe.wetware.tooltip=一个终极电路板
-metaitem.plate.asoc.name=ASoC
-metaitem.plate.asoc.tooltip=进阶芯片级系统
-metaitem.plate.circuit.name=集成逻辑电路
-metaitem.plate.circuit.tooltip=集成电路
-metaitem.plate.cpu.name=中央处理器
-metaitem.plate.cpu.tooltip=集成电路
-metaitem.plate.hpic.name=高功率集成电路
-metaitem.plate.hpic.tooltip=高功率电路
-metaitem.plate.nand.name=NAND存储器芯片
-metaitem.plate.nand.tooltip=集成电路
-metaitem.plate.nanocpu.name=纳米CPU
-metaitem.plate.nanocpu.tooltip=功率电路
-metaitem.plate.nor.name=NOR存储器芯片
-metaitem.plate.nor.tooltip=集成电路
-metaitem.plate.pic.name=功率集成电路
-metaitem.plate.pic.tooltip=功率电路
-metaitem.plate.qbit.name=QBit处理器
-metaitem.plate.qbit.tooltip=量子CPU
-metaitem.plate.ram.name=随机存取存储器芯片
-metaitem.plate.ram.tooltip=集成电路
-metaitem.plate.soc.name=SoC
-metaitem.plate.soc.tooltip=芯片级的系统
-metaitem.processor.crystal.name=晶体处理器
-metaitem.processor.crystal.tooltip=一个精英电路板
-metaitem.processor.nano.name=纳米处理器
-metaitem.processor.nano.tooltip=一个进阶电路板
-metaitem.processor.quantum.name=量子处理器
-metaitem.processor.quantum.tooltip=一个高级电路板
-metaitem.processor.wetware.name=湿件处理器
-metaitem.processor.wetware.tooltip=一个大师级电路板
-metaitem.wafer.asoc.name=ASoC晶元
-metaitem.wafer.asoc.tooltip=电路元件
-metaitem.wafer.circuit.name=集成逻辑电路(晶元)
-metaitem.wafer.circuit.tooltip=电路元件
-metaitem.wafer.cpu.name=中央处理器(晶元)
-metaitem.wafer.cpu.tooltip=电路元件
-metaitem.wafer.glowstone.name=萤石掺杂的晶元
-metaitem.wafer.glowstone.tooltip=电路元件
-metaitem.wafer.hpic.name=HPIC晶元
-metaitem.wafer.hpic.tooltip=电路元件
-metaitem.wafer.naquadah.name=硅岩掺杂的晶元
-metaitem.wafer.naquadah.tooltip=电路元件
-metaitem.wafer.nand.name=NAND存储器芯片(晶元)
-metaitem.wafer.nand.tooltip=电路元件
-metaitem.wafer.nanocpu.name=纳米CPU晶元
-metaitem.wafer.nanocpu.tooltip=电路元件
-metaitem.wafer.nor.name=NOR存储器芯片(晶元)
-metaitem.wafer.nor.tooltip=电路元件
-metaitem.wafer.pic.name=PIC晶元
-metaitem.wafer.pic.tooltip=电路元件
-metaitem.wafer.qbit.name=QBit晶元
-metaitem.wafer.qbit.tooltip=电路元件
-metaitem.wafer.ram.name=随机存取存储器芯片(晶元)
-metaitem.wafer.ram.tooltip=电路元件
-metaitem.wafer.silicon.name=晶元
+
+# Wafers and Components Tooltips
+metaitem.boule.silicon.tooltip=电路元件
+metaitem.boule.glowstone.tooltip=电路元件
+metaitem.boule.naquadah.tooltip=电路元件
+metaitem.plate.qbit_central_processing_unit.tooltip=Quantum CPU
 metaitem.wafer.silicon.tooltip=电路元件
-metaitem.wafer.soc.name=SoC晶元
-metaitem.wafer.soc.tooltip=电路元件
-metaitem.form.acacia.name=金合欢木砖范
-metaitem.form.birch.name=白桦木砖范
-metaitem.form.darkoak.name=深色橡木砖范
-metaitem.form.jungle.name=丛林木砖范
-metaitem.form.oak.name=橡木砖范
-metaitem.form.spruce.name=云杉木砖范
-metaitem.carbon.fibers.name=碳纤维
-metaitem.plate.mixed.metal.name=多层金属板
-metaitem.plate.advanced.alloy.name=进阶合金板
-metaitem.crystal.raw.name=晶体芯片原料
-metaitem.crystal.raw.tooltip=晶体处理器的原料
-metaitem.crystal.cpu.name=晶体处理器
-metaitem.crystal.cpu.tooltip=晶体CPU
-metaitem.crystal.soc.name=晶体SoC
-metaitem.crystal.soc.tooltip=晶体上的芯片级系统
-metaitem.stemcells.name=干细胞
+metaitem.wafer.glowstone.tooltip=电路元件
+metaitem.wafer.naquadah.tooltip=电路元件
+
+# Circuit Tooltips
+metaitem.circuit.basic.tooltip=一个基础的电路板
+metaitem.circuit.good.tooltip=A Good Circuit
+metaitem.circuit.advanced.tooltip=一个不错的电路板
+metaitem.circuit.wetware_mainframe.tooltip=An Infinite Circuit
+metaitem.circuit.vacuum_tube.tooltip=一个极其简易的电路板
+metaitem.circuit.advanced_parts.tooltip=A Basic Circuit
+
+# Item Tooltips
+metaitem.compressed.fireclay.tooltip=砖块状
 metaitem.stemcells.tooltip=智慧的原料
-metaitem.crystal.lapotron.name=兰波顿水晶
-metaitem.plate.iridium.alloy.name=铱合金板
-metaitem.plate.iridium.alloy.uncompressed.name=多层铱金属板
-metaitem.neutron.reflector.name=中子反射器
+metaitem.component.glass.fiber.tooltip=B(SiO2)7
+metaitem.component.petri.dish.tooltip=用以培养细胞
 
-gregtech.machine.circuit_assembler.lv.name=基础电路组装机
-gregtech.machine.circuit_assembler.mv.name=进阶电路组装机
-gregtech.machine.circuit_assembler.hv.name=进阶电路组装机 II
-gregtech.machine.circuit_assembler.ev.name=进阶电路组装机 III
-gregtech.machine.circuit_assembler.iv.name=进阶电路组装机 IV
-gregtech.machine.circuit_assembler.luv.name=进阶电路组装机 V
-gregtech.machine.circuit_assembler.zpm.name=进阶电路组装机 VI
-gregtech.machine.circuit_assembler.uv.name=进阶电路组装机 VII
 
-gregtech.machine.cluster_mill.lv.name=基础多辊式轧机
-gregtech.machine.cluster_mill.mv.name=进阶多辊式轧机
-gregtech.machine.cluster_mill.hv.name=进阶多辊式轧机 II
-gregtech.machine.cluster_mill.ev.name=进阶多辊式轧机 III
-gregtech.machine.cluster_mill.iv.name=进阶多辊式轧机 IV
-gregtech.machine.cluster_mill.luv.name=进阶多辊式轧机 V
-gregtech.machine.cluster_mill.zpm.name=进阶多辊式轧机 VI
-gregtech.machine.cluster_mill.uv.name=进阶多辊式轧机 VII
+## Item Names/Renames
 
-gregtech.machine.electric_furnace.iv.name=热应激发生器
-gregtech.machine.electric_furnace.luv.name=热应激发生器 II
-gregtech.machine.electric_furnace.zpm.name=热应激发生器 III
-gregtech.machine.electric_furnace.uv.name=热应激发生器 IV
+# Renaming Boules
+metaitem.boule.silicon.name=单晶硅
+metaitem.boule.glowstone.name=萤石掺杂的单晶硅
+metaitem.boule.naquadah.name=硅岩掺杂的单晶硅
 
-gregtech.machine.macerator.iv.name=矿石粉碎者 9001
-gregtech.machine.macerator.luv.name=矿石粉碎者 9002
-gregtech.machine.macerator.zpm.name=矿石粉碎者 9003
-gregtech.machine.macerator.uv.name=矿石粉碎者 9004
+# Naming Multiblock Parts
+tile.ga_multiblock_casing.tungstensteel_gearbox_casing.name=装配线机械方块
+tile.ga_transparent_casing.reinforced_glass.name=强化玻璃
 
-gregtech.machine.alloy_smelter.iv.name=进阶合金炉 IV
-gregtech.machine.alloy_smelter.luv.name=进阶合金炉 V
-gregtech.machine.alloy_smelter.zpm.name=进阶合金炉 VI
-gregtech.machine.alloy_smelter.uv.name=进阶合金炉 VII
+# Naming Batteries
+metaitem.energy.module.name=Energy Module
+metaitem.energy.cluster.name=Energy Cluster
+metaitem.max.battery.name=MAX Battery
 
-gregtech.machine.amplifab.iv.name=进阶UU增幅液生产器 IV
-gregtech.machine.amplifab.luv.name=进阶UU增幅液生产器 V
-gregtech.machine.amplifab.zpm.name=进阶UU增幅液生产器 VI
-gregtech.machine.amplifab.uv.name=进阶UU增幅液生产器 VII
+# Naming Items
+metaitem.component.petri.dish.name=培养皿
+metaitem.compressed.clay.name=砖坯
+metaitem.stemcells.name=干细胞
+metaitem.credit.darmstadtium.name=中子素币
+metaitem.rubber_drop.name=粘性树脂
+metaitem.component.glass.fiber.name=玻璃纤维
+metaitem.compressed.coke.clay.name=焦炉砖坯
 
-gregtech.machine.arc_furnace.iv.name=进阶电弧炉 IV
-gregtech.machine.arc_furnace.luv.name=进阶电弧炉 V
-gregtech.machine.arc_furnace.zpm.name=进阶电弧炉 VI
-gregtech.machine.arc_furnace.uv.name=进阶电弧炉 VII
+# Renaming Circuits
+metaitem.circuit.integrated.name=编程电路
+metaitem.circuit.advanced.name=集成处理器
+metaitem.circuit.crystal_processor.name=Crystal Processor
+metaitem.circuit.nano_processor.name=Nano Processor
+metaitem.circuit.quantum_processor.name=Quantum Processor
+metaitem.processor.neuro.name=Neuro Processing Unit
 
+# Naming Schematics
+metaitem.schematic.dust.name=Schematic (Dust)
+metaitem.schematic.3by3.name=Schematic (3x3)
+metaitem.schematic.2by2.name=Schematic (2x2)
+metaitem.schematic.name=Blank Schematic
+
+# Renaming Rubber Components
+item.epoxid.ingot=环氧树脂条
+item.epoxid.dustTiny=小撮环氧树脂末
+item.epoxid.dustSmall=小堆环氧树脂末
+item.epoxid.dust=环氧树脂末
+item.epoxid.nugget=环氧树脂颗粒
+item.epoxid.plate=环氧树脂片
+item.epoxid.foil=薄环氧树脂片
+item.reinforced_epoxy_resin.ingot=纤维强化的环氧树脂条
+item.reinforced_epoxy_resin.dustTiny=小撮纤维强化的环氧树脂末
+item.reinforced_epoxy_resin.dustSmall=小堆纤维强化的环氧树脂末
+item.reinforced_epoxy_resin.dust=纤维强化的环氧树脂末
+item.reinforced_epoxy_resin.nugget=纤维强化的环氧树脂颗粒
+item.reinforced_epoxy_resin.plate=纤维强化的环氧树脂片
+item.borosilicate_glass.ingot=硼硅玻璃条
+item.borosilicate_glass.dustTiny=小撮硼硅玻璃末
+item.borosilicate_glass.dustSmall=小堆硼硅玻璃末
+item.borosilicate_glass.dust=硼硅玻璃末
+item.borosilicate_glass.nugget=硼硅玻璃颗粒
+item.polyvinyl_chloride.ingot=聚氯乙烯条
+item.polyvinyl_chloride.dustTiny=小撮聚氯乙烯末
+item.polyvinyl_chloride.dustSmall=小堆聚氯乙烯末
+item.polyvinyl_chloride.dust=聚氯乙烯末
+item.polyvinyl_chloride.nugget=聚氯乙烯颗粒
+item.polyvinyl_chloride.plateDense=致密聚氯乙烯片
+item.polyvinyl_chloride.plate=聚氯乙烯片
+item.polyvinyl_chloride.foil=薄聚氯乙烯片
+item.silicon_rubber.ingot=硅橡胶条
+item.silicon_rubber.dustTiny=小撮硅橡胶末
+item.silicon_rubber.dustSmall=小堆硅橡胶末
+item.silicon_rubber.dust=硅橡胶末
+item.silicon_rubber.nugget=硅橡胶颗粒
+item.silicon_rubber.plate=硅橡胶片
+item.silicon_rubber.foil=薄硅橡胶片
+item.polystyrene.ingot=聚苯乙烯条
+item.polystyrene.dustTiny=小撮聚苯乙烯末
+item.polystyrene.dustSmall=小堆聚苯乙烯末
+item.polystyrene.dust=聚苯乙烯末
+item.polystyrene.nugget=聚苯乙烯颗粒
+item.polystyrene.plate=聚苯乙烯片
+item.polystyrene.foil=薄聚苯乙烯片
+item.styrene_butadiene_rubber.ingot=丁苯橡胶条
+item.styrene_butadiene_rubber.dustTiny=小撮丁苯橡胶末
+item.styrene_butadiene_rubber.dustSmall=小堆丁苯橡胶末
+item.styrene_butadiene_rubber.dust=丁苯橡胶末
+item.styrene_butadiene_rubber.nugget=丁苯橡胶颗粒
+item.styrene_butadiene_rubber.plate=丁苯橡胶片
+
+# Renaming Meat parts
+item.meat.dustTiny=小撮肉末
+item.meat.dustSmall=小堆肉末
+item.meat.dust=肉末
+
+
+## Higher Tier Machines
+
+# Cluster Mill
+recipemap.cluster_mill.name=多辊式轧机
+gtadditions.machine.cluster_mill.lv.name=基础多辊式轧机
+gtadditions.machine.cluster_mill.mv.name=进阶多辊式轧机
+gtadditions.machine.cluster_mill.hv.name=进阶多辊式轧机 II
+gtadditions.machine.cluster_mill.ev.name=进阶多辊式轧机 III
+gtadditions.machine.cluster_mill.iv.name=进阶多辊式轧机 IV
+gtadditions.machine.cluster_mill.luv.name=进阶多辊式轧机 V
+gtadditions.machine.cluster_mill.zpm.name=进阶多辊式轧机 VI
+gtadditions.machine.cluster_mill.uv.name=进阶多辊式轧机 VII
+
+# Electric Furnace
+gtadditions.machine.electric_furnace.iv.name=热应激发生器
+gtadditions.machine.electric_furnace.luv.name=热应激发生器 II
+gtadditions.machine.electric_furnace.zpm.name=热应激发生器 III
+gtadditions.machine.electric_furnace.uv.name=热应激发生器 IV
+
+# Macerator
+gtadditions.machine.macerator.iv.name=Universal Pulverizer II
+gtadditions.machine.macerator.iv.tooltip=矿石粉碎者 9001
+gtadditions.machine.macerator.luv.name=Universal Pulverizer III
+gtadditions.machine.macerator.luv.tooltip=矿石粉碎者 9002
+gtadditions.machine.macerator.zpm.name=Universal Pulverizer IV
+gtadditions.machine.macerator.zpm.tooltip=矿石粉碎者 9003
+gtadditions.machine.macerator.uv.name=Universal Pulverizer V
+gtadditions.machine.macerator.uv.tooltip=矿石粉碎者 9004
+
+# Alloy Smelter
+gtadditions.machine.alloy_smelter.iv.name=进阶合金炉 IV
+gtadditions.machine.alloy_smelter.luv.name=进阶合金炉 V
+gtadditions.machine.alloy_smelter.zpm.name=进阶合金炉 VI
+gtadditions.machine.alloy_smelter.uv.name=进阶合金炉 VII
+
+# Amplifabricator
+gtadditions.machine.amplifab.iv.name=进阶UU增幅液生产器 IV
+gtadditions.machine.amplifab.luv.name=进阶UU增幅液生产器 V
+gtadditions.machine.amplifab.zpm.name=进阶UU增幅液生产器 VI
+gtadditions.machine.amplifab.uv.name=进阶UU增幅液生产器 VII
+
+# Arc Furnace
+gtadditions.machine.arc_furnace.iv.name=进阶电弧炉 IV
+gtadditions.machine.arc_furnace.luv.name=进阶电弧炉 V
+gtadditions.machine.arc_furnace.zpm.name=进阶电弧炉 VI
+gtadditions.machine.arc_furnace.uv.name=进阶电弧炉 VII
+
+# Assembling Machine
 gregtech.machine.assembler.iv.name=进阶组装机 IV
-gregtech.machine.assembler.luv.name=进阶组装机 V
-gregtech.machine.assembler.zpm.name=进阶组装机 VI
-gregtech.machine.assembler.uv.name=进阶组装机 VII
+gtadditions.machine.assembler.luv.name=进阶组装机 V
+gtadditions.machine.assembler.zpm.name=进阶组装机 VI
+gtadditions.machine.assembler.uv.name=进阶组装机 VII
 
+# Autoclave
 gregtech.machine.autoclave.iv.name=进阶高压釜 IV
-gregtech.machine.autoclave.luv.name=进阶高压釜 V
-gregtech.machine.autoclave.zpm.name=进阶高压釜 VI
-gregtech.machine.autoclave.uv.name=进阶高压釜 VII
+gtadditions.machine.autoclave.luv.name=进阶高压釜 V
+gtadditions.machine.autoclave.zpm.name=进阶高压釜 VI
+gtadditions.machine.autoclave.uv.name=进阶高压釜 VII
 
-gregtech.machine.bender.iv.name=进阶卷板机 IV
-gregtech.machine.bender.luv.name=进阶卷板机 V
-gregtech.machine.bender.zpm.name=进阶卷板机 VI
-gregtech.machine.bender.uv.name=进阶卷板机 VII
+# Bender
+gtadditions.machine.bender.iv.name=进阶卷板机 IV
+gtadditions.machine.bender.luv.name=进阶卷板机 V
+gtadditions.machine.bender.zpm.name=进阶卷板机 VI
+gtadditions.machine.bender.uv.name=进阶卷板机 VII
 
-gregtech.machine.brewery.iv.name=进阶酿造室 IV
-gregtech.machine.brewery.luv.name=进阶酿造室 V
-gregtech.machine.brewery.zpm.name=进阶酿造室 VI
-gregtech.machine.brewery.uv.name=进阶酿造室 VII
+# Brewery
+gtadditions.machine.brewery.iv.name=进阶酿造室 IV
+gtadditions.machine.brewery.luv.name=进阶酿造室 V
+gtadditions.machine.brewery.zpm.name=进阶酿造室 VI
+gtadditions.machine.brewery.uv.name=进阶酿造室 VII
 
-gregtech.machine.canner.iv.name=进阶装罐机 IV
-gregtech.machine.canner.luv.name=进阶装罐机 V
-gregtech.machine.canner.zpm.name=进阶装罐机 VI
-gregtech.machine.canner.uv.name=进阶装罐机 VII
+# Canner
+gtadditions.machine.canner.iv.name=进阶装罐机 IV
+gtadditions.machine.canner.luv.name=进阶装罐机 V
+gtadditions.machine.canner.zpm.name=进阶装罐机 VI
+gtadditions.machine.canner.uv.name=进阶装罐机 VII
 
-gregtech.machine.centrifuge.ev.name=分子离心机
-gregtech.machine.centrifuge.iv.name=旋风分子离心机
-gregtech.machine.centrifuge.luv.name=旋风分子离心机 II
-gregtech.machine.centrifuge.zpm.name=旋风分子离心机 III
-gregtech.machine.centrifuge.uv.name=旋风分子离心机 IV
+# Centrifuge
+gtadditions.machine.centrifuge.iv.name=旋风分子离心机
+gtadditions.machine.centrifuge.iv.tooltip=Molecular Cyclone
+gtadditions.machine.centrifuge.luv.name=旋风分子离心机 II
+gtadditions.machine.centrifuge.luv.tooltip=Molecular Cyclone
+gtadditions.machine.centrifuge.zpm.name=旋风分子离心机 III
+gtadditions.machine.centrifuge.zpm.tooltip=Molecular Cyclone
+gtadditions.machine.centrifuge.uv.name=旋风分子离心机 IV
+gtadditions.machine.centrifuge.uv.tooltip=Molecular Cyclone
 
-gregtech.machine.chemical_bath.iv.name=进阶化学浸洗器 IV
-gregtech.machine.chemical_bath.luv.name=进阶化学浸洗器 V
-gregtech.machine.chemical_bath.zpm.name=进阶化学浸洗器 VI
-gregtech.machine.chemical_bath.uv.name=进阶化学浸洗器 VII
+# Chemical Bath
+gtadditions.machine.chemical_bath.iv.name=进阶化学浸洗器 IV
+gtadditions.machine.chemical_bath.luv.name=进阶化学浸洗器 V
+gtadditions.machine.chemical_bath.zpm.name=进阶化学浸洗器 VI
+gtadditions.machine.chemical_bath.uv.name=进阶化学浸洗器 VII
 
-gregtech.machine.chemical_reactor.iv.name=进阶化学反应釜 IV
-gregtech.machine.chemical_reactor.luv.name=进阶化学反应釜 V
-gregtech.machine.chemical_reactor.zpm.name=进阶化学反应釜 VI
-gregtech.machine.chemical_reactor.uv.name=进阶化学反应釜 VII
+# Chemical Reactor
+gtadditions.machine.chemical_reactor.iv.name=进阶化学反应釜 IV
+gtadditions.machine.chemical_reactor.luv.name=进阶化学反应釜 V
+gtadditions.machine.chemical_reactor.zpm.name=进阶化学反应釜 VI
+gtadditions.machine.chemical_reactor.uv.name=进阶化学反应釜 VII
 
+# Compressor
 gregtech.machine.compressor.ev.name=进阶压缩机 III
-gregtech.machine.compressor.iv.name=奇点压缩机
-gregtech.machine.compressor.luv.name=奇点压缩机 II
-gregtech.machine.compressor.zpm.name=奇点压缩机 III
-gregtech.machine.compressor.uv.name=奇点压缩机 IV
+gtadditions.machine.compressor.iv.name=奇点压缩机
+gtadditions.machine.compressor.luv.name=奇点压缩机 II
+gtadditions.machine.compressor.zpm.name=奇点压缩机 III
+gtadditions.machine.compressor.uv.name=奇点压缩机 IV
 
-gregtech.machine.cutter.iv.name=进阶板材切割机 IV
-gregtech.machine.cutter.luv.name=进阶板材切割机 V
-gregtech.machine.cutter.zpm.name=进阶板材切割机 VI
-gregtech.machine.cutter.uv.name=进阶板材切割机 VII
+# Cutter
+gtadditions.machine.cutter.iv.name=进阶板材切割机 IV
+gtadditions.machine.cutter.luv.name=进阶板材切割机 V
+gtadditions.machine.cutter.zpm.name=进阶板材切割机 VI
+gtadditions.machine.cutter.uv.name=进阶板材切割机 VII
 
-gregtech.machine.distillery.iv.name=进阶蒸馏室 IV
-gregtech.machine.distillery.luv.name=进阶蒸馏室 V
-gregtech.machine.distillery.zpm.name=进阶蒸馏室 VI
-gregtech.machine.distillery.uv.name=进阶蒸馏室 VII
+# Distillery
+gtadditions.machine.distillery.iv.name=进阶蒸馏室 IV
+gtadditions.machine.distillery.luv.name=进阶蒸馏室 V
+gtadditions.machine.distillery.zpm.name=进阶蒸馏室 VI
+gtadditions.machine.distillery.uv.name=进阶蒸馏室 VII
 
+# Electrolyzer
 gregtech.machine.electrolyzer.ev.name=进阶电解机 III
-gregtech.machine.electrolyzer.iv.name=分子分解者E-4905
-gregtech.machine.electrolyzer.luv.name=分子分解者E-4906
-gregtech.machine.electrolyzer.zpm.name=分子分解者E-4907
-gregtech.machine.electrolyzer.uv.name=分子分解者E-4908
+gtadditions.machine.electrolyzer.iv.name=Advanced Electrolyzer IV
+gtadditions.machine.electrolyzer.iv.tooltip=分子分解者E-4905
+gtadditions.machine.electrolyzer.luv.name=Elite Electrolyzer
+gtadditions.machine.electrolyzer.luv.tooltip=分子分解者E-4906
+gtadditions.machine.electrolyzer.zpm.name=Elite Electrolyzer II
+gtadditions.machine.electrolyzer.zpm.tooltip=分子分解者E-4907
+gtadditions.machine.electrolyzer.uv.name=Elite Electrolyzer III
+gtadditions.machine.electrolyzer.uv.tooltip=分子分解者E-4908
 
-gregtech.machine.electromagnetic_separator.iv.name=进阶电磁离析机 IV
-gregtech.machine.electromagnetic_separator.luv.name=进阶电磁离析机 V
-gregtech.machine.electromagnetic_separator.zpm.name=进阶电磁离析机 VI
-gregtech.machine.electromagnetic_separator.uv.name=进阶电磁离析机 VII
+# Electromagnetic Separator
+gtadditions.machine.electromagnetic_separator.iv.name=进阶电磁离析机 IV
+gtadditions.machine.electromagnetic_separator.luv.name=进阶电磁离析机 V
+gtadditions.machine.electromagnetic_separator.zpm.name=进阶电磁离析机 VI
+gtadditions.machine.electromagnetic_separator.uv.name=进阶电磁离析机 VII
 
+# Extractor
 gregtech.machine.extractor.ev.name=进阶提取机 III
-gregtech.machine.extractor.iv.name=真空提取机
-gregtech.machine.extractor.luv.name=真空提取机 II
-gregtech.machine.extractor.zpm.name=真空提取机 III
-gregtech.machine.extractor.uv.name=真空提取机 IV
+gtadditions.machine.extractor.iv.name=真空提取机
+gtadditions.machine.extractor.luv.name=真空提取机 II
+gtadditions.machine.extractor.zpm.name=真空提取机 III
+gtadditions.machine.extractor.uv.name=真空提取机 IV
 
-gregtech.machine.extruder.iv.name=进阶压模器 IV
-gregtech.machine.extruder.luv.name=进阶压模器 V
-gregtech.machine.extruder.zpm.name=进阶压模器 VI
-gregtech.machine.extruder.uv.name=进阶压模器 VII
+# Extruder
+gtadditions.machine.extruder.iv.name=进阶压模器 IV
+gtadditions.machine.extruder.luv.name=进阶压模器 V
+gtadditions.machine.extruder.zpm.name=进阶压模器 VI
+gtadditions.machine.extruder.uv.name=进阶压模器 VII
 
-gregtech.machine.fermenter.iv.name=进阶发酵槽 IV
-gregtech.machine.fermenter.luv.name=进阶发酵槽 V
-gregtech.machine.fermenter.zpm.name=进阶发酵槽 VI
-gregtech.machine.fermenter.uv.name=进阶发酵槽 VII
+# Fermenter
+gtadditions.machine.fermenter.iv.name=进阶发酵槽 IV
+gtadditions.machine.fermenter.luv.name=进阶发酵槽 V
+gtadditions.machine.fermenter.zpm.name=进阶发酵槽 VI
+gtadditions.machine.fermenter.uv.name=进阶发酵槽 VII
 
-gregtech.machine.fluid_canner.iv.name=音速流体灌装机
-gregtech.machine.fluid_canner.luv.name=音速流体灌装机 II
-gregtech.machine.fluid_canner.zpm.name=音速流体灌装机 III
-gregtech.machine.fluid_canner.uv.name=音速流体灌装机 IV
+# Fluid Canner
+gtadditions.machine.fluid_canner.iv.name=音速流体灌装机
+gtadditions.machine.fluid_canner.luv.name=音速流体灌装机 II
+gtadditions.machine.fluid_canner.zpm.name=音速流体灌装机 III
+gtadditions.machine.fluid_canner.uv.name=音速流体灌装机 IV
 
-gregtech.machine.fluid_extractor.iv.name=进阶流体提取机 IV
-gregtech.machine.fluid_extractor.luv.name=进阶流体提取机 V
-gregtech.machine.fluid_extractor.zpm.name=进阶流体提取机 VI
-gregtech.machine.fluid_extractor.uv.name=进阶流体提取机 VII
+# Fluid Extractor
+gtadditions.machine.fluid_extractor.iv.name=进阶流体提取机 IV
+gtadditions.machine.fluid_extractor.luv.name=进阶流体提取机 V
+gtadditions.machine.fluid_extractor.zpm.name=进阶流体提取机 VI
+gtadditions.machine.fluid_extractor.uv.name=进阶流体提取机 VII
 
-gregtech.machine.fluid_heater.iv.name=进阶流体加热器 IV
-gregtech.machine.fluid_heater.luv.name=进阶流体加热器 V
-gregtech.machine.fluid_heater.zpm.name=进阶流体加热器 VI
-gregtech.machine.fluid_heater.uv.name=进阶流体加热器 VII
+# Fluid Heater
+gtadditions.machine.fluid_heater.iv.name=进阶流体加热器 IV
+gtadditions.machine.fluid_heater.luv.name=进阶流体加热器 V
+gtadditions.machine.fluid_heater.zpm.name=进阶流体加热器 VI
+gtadditions.machine.fluid_heater.uv.name=进阶流体加热器 VII
 
-gregtech.machine.fluid_solidifier.iv.name=进阶流体固化器 IV
-gregtech.machine.fluid_solidifier.luv.name=进阶流体固化器 V
-gregtech.machine.fluid_solidifier.zpm.name=进阶流体固化器 VI
-gregtech.machine.fluid_solidifier.uv.name=进阶流体固化器 VII
+# Fluid Solidifier
+gtadditions.machine.fluid_solidifier.iv.name=进阶流体固化器 IV
+gtadditions.machine.fluid_solidifier.luv.name=进阶流体固化器 V
+gtadditions.machine.fluid_solidifier.zpm.name=进阶流体固化器 VI
+gtadditions.machine.fluid_solidifier.uv.name=进阶流体固化器 VII
 
-gregtech.machine.forge_hammer.iv.name=进阶锻造锤 IV
-gregtech.machine.forge_hammer.luv.name=进阶锻造锤 V
-gregtech.machine.forge_hammer.zpm.name=进阶锻造锤 VI
-gregtech.machine.forge_hammer.uv.name=进阶锻造锤 VII
+# Forge Hammer
+gtadditions.machine.forge_hammer.iv.name=进阶锻造锤 IV
+gtadditions.machine.forge_hammer.luv.name=进阶锻造锤 V
+gtadditions.machine.forge_hammer.zpm.name=进阶锻造锤 VI
+gtadditions.machine.forge_hammer.uv.name=进阶锻造锤 VII
 
-gregtech.machine.forming_press.iv.name=进阶冲压机床 IV
-gregtech.machine.forming_press.luv.name=进阶冲压机床 V
-gregtech.machine.forming_press.zpm.name=进阶冲压机床 VI
-gregtech.machine.forming_press.uv.name=进阶冲压机床 VII
+# Forming Press
+gtadditions.machine.forming_press.iv.name=进阶冲压机床 IV
+gtadditions.machine.forming_press.luv.name=进阶冲压机床 V
+gtadditions.machine.forming_press.zpm.name=进阶冲压机床 VI
+gtadditions.machine.forming_press.uv.name=进阶冲压机床 VII
 
-gregtech.machine.lathe.iv.name=进阶车床 IV
-gregtech.machine.lathe.luv.name=进阶车床 V
-gregtech.machine.lathe.zpm.name=进阶车床 VI
-gregtech.machine.lathe.uv.name=进阶车床 VII
+# Lathe
+gtadditions.machine.lathe.iv.name=进阶车床 IV
+gtadditions.machine.lathe.luv.name=进阶车床 V
+gtadditions.machine.lathe.zpm.name=进阶车床 VI
+gtadditions.machine.lathe.uv.name=进阶车床 VII
 
-gregtech.machine.microwave.iv.name=进阶微波炉 IV
-gregtech.machine.microwave.luv.name=进阶微波炉 V
-gregtech.machine.microwave.zpm.name=进阶微波炉 VI
-gregtech.machine.microwave.uv.name=进阶微波炉 VII
+# Microwave
+gtadditions.machine.microwave.iv.name=进阶微波炉 IV
+gtadditions.machine.microwave.luv.name=进阶微波炉 V
+gtadditions.machine.microwave.zpm.name=进阶微波炉 VI
+gtadditions.machine.microwave.uv.name=进阶微波炉 VII
 
-gregtech.machine.mixer.iv.name=进阶搅拌机 IV
-gregtech.machine.mixer.luv.name=进阶搅拌机 V
-gregtech.machine.mixer.zpm.name=进阶搅拌机 VI
-gregtech.machine.mixer.uv.name=进阶搅拌机 VII
+# Mixer
+gtadditions.machine.mixer.iv.name=进阶搅拌机 IV
+gtadditions.machine.mixer.luv.name=进阶搅拌机 V
+gtadditions.machine.mixer.zpm.name=进阶搅拌机 VI
+gtadditions.machine.mixer.uv.name=进阶搅拌机 VII
 
-gregtech.machine.ore_washer.iv.name=波轮洗矿厂I-360
-gregtech.machine.ore_washer.luv.name=波轮洗矿厂I-720
-gregtech.machine.ore_washer.zpm.name=波轮洗矿厂I-1080
-gregtech.machine.ore_washer.uv.name=波轮洗矿厂I-1440
+# Ore Washer
+gtadditions.machine.ore_washer.iv.name=Advanced Ore Washing Plant IV
+gtadditions.machine.ore_washer.iv.tooltip=波轮洗矿厂I-360
+gtadditions.machine.ore_washer.luv.name=Elite Ore Washing Plant
+gtadditions.machine.ore_washer.luv.tooltip=波轮洗矿厂I-720
+gtadditions.machine.ore_washer.zpm.name=Elite Ore Washing Plant II
+gtadditions.machine.ore_washer.zpm.tooltip=波轮洗矿厂I-1080
+gtadditions.machine.ore_washer.uv.name=Elite Ore Washing Plant III
+gtadditions.machine.ore_washer.uv.tooltip=波轮洗矿厂I-1440
 
-gregtech.machine.packer.iv.name=装箱者
-gregtech.machine.packer.luv.name=装箱者 II
-gregtech.machine.packer.zpm.name=装箱者 III
-gregtech.machine.packer.uv.name=装箱者 IV
+# Packer
+gtadditions.machine.packer.iv.name=装箱者
+gtadditions.machine.packer.luv.name=装箱者 II
+gtadditions.machine.packer.zpm.name=装箱者 III
+gtadditions.machine.packer.uv.name=装箱者 IV
 
-gregtech.machine.unpacker.iv.name=拆箱者
-gregtech.machine.unpacker.luv.name=拆箱者 II
-gregtech.machine.unpacker.zpm.name=拆箱者 III
-gregtech.machine.unpacker.uv.name=拆箱者 IV
+# Unpacker
+gtadditions.machine.unpacker.iv.name=拆箱者
+gtadditions.machine.unpacker.luv.name=拆箱者 II
+gtadditions.machine.unpacker.zpm.name=拆箱者 III
+gtadditions.machine.unpacker.uv.name=拆箱者 IV
 
-gregtech.machine.plasma_arc_furnace.iv.name=进阶等离子电弧炉 IV
-gregtech.machine.plasma_arc_furnace.luv.name=进阶等离子电弧炉 V
-gregtech.machine.plasma_arc_furnace.zpm.name=进阶等离子电弧炉 VI
-gregtech.machine.plasma_arc_furnace.uv.name=进阶等离子电弧炉 VII
+# Plasma Arc Furnace
+gtadditions.machine.plasma_arc_furnace.iv.name=进阶等离子电弧炉 IV
+gtadditions.machine.plasma_arc_furnace.luv.name=进阶等离子电弧炉 V
+gtadditions.machine.plasma_arc_furnace.zpm.name=进阶等离子电弧炉 VI
+gtadditions.machine.plasma_arc_furnace.uv.name=进阶等离子电弧炉 VII
 
-gregtech.machine.polarizer.iv.name=进阶两极磁化机 IV
-gregtech.machine.polarizer.luv.name=进阶两极磁化机 V
-gregtech.machine.polarizer.zpm.name=进阶两极磁化机 VI
-gregtech.machine.polarizer.uv.name=进阶两极磁化机 VII
+# Polarizer
+gtadditions.machine.polarizer.iv.name=进阶两极磁化机 IV
+gtadditions.machine.polarizer.luv.name=进阶两极磁化机 V
+gtadditions.machine.polarizer.zpm.name=进阶两极磁化机 VI
+gtadditions.machine.polarizer.uv.name=进阶两极磁化机 VII
 
-gregtech.machine.laser_engraver.iv.name=进阶精密激光蚀刻机 IV
-gregtech.machine.laser_engraver.luv.name=进阶精密激光蚀刻机 V
-gregtech.machine.laser_engraver.zpm.name=进阶精密激光蚀刻机 VI
-gregtech.machine.laser_engraver.uv.name=进阶精密激光蚀刻机 VII
+# Laser Engraver
+gtadditions.machine.laser_engraver.iv.name=进阶精密激光蚀刻机 IV
+gtadditions.machine.laser_engraver.luv.name=进阶精密激光蚀刻机 V
+gtadditions.machine.laser_engraver.zpm.name=进阶精密激光蚀刻机 VI
+gtadditions.machine.laser_engraver.uv.name=进阶精密激光蚀刻机 VII
 
-gregtech.machine.sifter.iv.name=进阶筛选机 IV
-gregtech.machine.sifter.luv.name=进阶筛选机 V
-gregtech.machine.sifter.zpm.name=进阶筛选机 VI
-gregtech.machine.sifter.uv.name=进阶筛选机 VII
+# Shifter
+gtadditions.machine.sifter.iv.name=进阶筛选机 IV
+gtadditions.machine.sifter.luv.name=进阶筛选机 V
+gtadditions.machine.sifter.zpm.name=进阶筛选机 VI
+gtadditions.machine.sifter.uv.name=进阶筛选机 VII
 
-gregtech.machine.thermal_centrifuge.iv.name=烈焰分离厂T-6350
-gregtech.machine.thermal_centrifuge.luv.name=烈焰分离厂T-6360
-gregtech.machine.thermal_centrifuge.zpm.name=烈焰分离厂T-6370
-gregtech.machine.thermal_centrifuge.uv.name=烈焰分离厂T-6380
+# Thermal Centrifuge
+gtadditions.machine.thermal_centrifuge.iv.name=Advanced Thermal Centrifuge IV
+gtadditions.machine.thermal_centrifuge.iv.tooltip=烈焰分离厂T-6350
+gtadditions.machine.thermal_centrifuge.luv.name=Elite Thermal Centrifuge
+gtadditions.machine.thermal_centrifuge.luv.tooltip=烈焰分离厂T-6360
+gtadditions.machine.thermal_centrifuge.zpm.name=Elite Thermal Centrifuge II
+gtadditions.machine.thermal_centrifuge.zpm.tooltip=烈焰分离厂T-6370
+gtadditions.machine.thermal_centrifuge.uv.name=Elite Thermal Centrifuge III
+gtadditions.machine.thermal_centrifuge.uv.tooltip=烈焰分离厂T-6380
 
-gregtech.machine.wiremill.iv.name=进阶线材轧机 IV
-gregtech.machine.wiremill.luv.name=进阶线材轧机 V
-gregtech.machine.wiremill.zpm.name=进阶线材轧机 VI
-gregtech.machine.wiremill.uv.name=进阶线材轧机 VII
+# Wiremill
+gtadditions.machine.wiremill.iv.name=进阶线材轧机 IV
+gtadditions.machine.wiremill.luv.name=进阶线材轧机 V
+gtadditions.machine.wiremill.zpm.name=进阶线材轧机 VI
+gtadditions.machine.wiremill.uv.name=进阶线材轧机 VII
 
-gregtech.machine.distill_tower.name=蒸馏塔
-gregtech.machine.assembly_line.name=装配线
-gregtech.machine.coke_oven.name=工业焦炉
-gregtech.machine.cracker_unit.name=石油裂化机
+# Naquadah Reactor
+recipemap.naquadah_reactor.name=硅岩反应堆燃料
+gtadditions.machine.naquadah_reactor.mk1.name=硅岩反应堆 Mk I
+gtadditions.machine.naquadah_reactor.mk2.name=硅岩反应堆 Mk II
+gtadditions.machine.naquadah_reactor.mk3.name=硅岩反应堆 Mk III
+gtadditions.machine.naquadah_reactor.mk4.name=硅岩反应堆 Mk IV
 
-gregtech.machine.naquadah_reactor.mk1.name=硅岩反应堆 Mk I
-gregtech.machine.naquadah_reactor.mk2.name=硅岩反应堆 Mk II
-gregtech.machine.naquadah_reactor.mk3.name=硅岩反应堆 Mk III
-gregtech.machine.naquadah_reactor.mk4.name=硅岩反应堆 Mk IV
+# Mass Fabricator
+recipemap.mass_fab.name=质量发生器
+gtadditions.machine.mass_fab.lv.name=基础质量发生器
+gtadditions.machine.mass_fab.mv.name=进阶质量发生器
+gtadditions.machine.mass_fab.hv.name=进阶质量发生器 II
+gtadditions.machine.mass_fab.ev.name=进阶质量发生器 III
+gtadditions.machine.mass_fab.iv.name=进阶质量发生器 IV
+gtadditions.machine.mass_fab.luv.name=进阶质量发生器 V
+gtadditions.machine.mass_fab.zpm.name=进阶质量发生器 VI
+gtadditions.machine.mass_fab.uv.name=进阶质量发生器 VII
 
-gregtech.machine.mass_fab.lv.name=基础质量发生器
-gregtech.machine.mass_fab.mv.name=进阶质量发生器
-gregtech.machine.mass_fab.hv.name=进阶质量发生器 II
-gregtech.machine.mass_fab.ev.name=进阶质量发生器 III
-gregtech.machine.mass_fab.iv.name=进阶质量发生器 IV
-gregtech.machine.mass_fab.luv.name=进阶质量发生器 V
-gregtech.machine.mass_fab.zpm.name=进阶质量发生器 VI
-gregtech.machine.mass_fab.uv.name=进阶质量发生器 VII
+# Replicator
+gtadditions.machine.replicator.lv.name=基础复制机
+gtadditions.machine.replicator.lv.tooltip=生产最纯净的元素
+gtadditions.machine.replicator.mv.name=进阶复制机
+gtadditions.machine.replicator.mv.tooltip=生产最纯净的元素
+gtadditions.machine.replicator.hv.name=进阶复制机 II
+gtadditions.machine.replicator.hv.tooltip=生产最纯净的元素
+gtadditions.machine.replicator.ev.name=进阶复制机 III
+gtadditions.machine.replicator.ev.tooltip=生产最纯净的元素
+gtadditions.machine.replicator.iv.name=进阶复制机 IV
+gtadditions.machine.replicator.iv.tooltip=生产最纯净的元素
+gtadditions.machine.replicator.luv.name=进阶复制机 V
+gtadditions.machine.replicator.luv.tooltip=生产最纯净的元素
+gtadditions.machine.replicator.zpm.name=进阶复制机 VI
+gtadditions.machine.replicator.zpm.tooltip=生产最纯净的元素
+gtadditions.machine.replicator.uv.name=进阶复制机 VII
+gtadditions.machine.replicator.uv.tooltip=生产最纯净的元素
 
-gregtech.machine.replicator.lv.name=基础复制机
-gregtech.machine.replicator.mv.name=进阶复制机
-gregtech.machine.replicator.hv.name=进阶复制机 II
-gregtech.machine.replicator.ev.name=进阶复制机 III
-gregtech.machine.replicator.iv.name=进阶复制机 IV
-gregtech.machine.replicator.luv.name=进阶复制机 V
-gregtech.machine.replicator.zpm.name=进阶复制机 VI
-gregtech.machine.replicator.uv.name=进阶复制机 VII
-
-gregtech.machine.pump.iv.name=进阶泵 IV
-gregtech.machine.pump.luv.name=进阶泵 V
-gregtech.machine.pump.zpm.name=进阶泵 VI
-gregtech.machine.pump.uv.name=进阶泵 VII
-
-gregtech.machine.air_collector.ev.name=进阶空气收集器 III
-gregtech.machine.air_collector.iv.name=大气收集器
-gregtech.machine.air_collector.luv.name=大气收集器 II
-
-gregtech.machine.replicator.tooltip=生产最纯净的元素
-
-gregtech.machine.fusion_reactor.luv.name=核聚变反应堆控制电脑 Mk I
-gregtech.machine.fusion_reactor.zpm.name=核聚变反应堆控制电脑 Mk II
-gregtech.machine.fusion_reactor.uv.name=核聚变反应堆控制电脑 Mk III
-
+# Bundler
+recipemap.bundler.name=Wire Bundling
 gtadditions.machine.bundler.lv.name=Basic Bundler
 gtadditions.machine.bundler.mv.name=Advanced Bundler
 gtadditions.machine.bundler.hv.name=Advanced Bundler II
@@ -431,266 +459,79 @@ gtadditions.machine.bundler.zpm.tooltip=Lapinotron 6000
 gtadditions.machine.bundler.uv.name=Elite Bundler III
 gtadditions.machine.bundler.uv.tooltip=Lapinotron 9000
 
-gregtech.machine.coke_item_bus.name=焦炉料斗
-gregtech.machine.coke_fluid_hatch.name=焦炉龙头
 
-tile.ga_multiblock_casing.coke_oven_bricks.name=焦炉砖
-tile.ga_multiblock_casing.tungstensteel_gearbox_casing.name=装配线机械方块
-tile.ga_transparent_casing.reinforced_glass.name=强化玻璃
+# Pump
+gtadditions.machine.pump.iv.name=进阶泵 IV
+gtadditions.machine.pump.luv.name=进阶泵 V
+gtadditions.machine.pump.zpm.name=进阶泵 VI
+gtadditions.machine.pump.uv.name=进阶泵 VII
 
-metaitem.tool.bending_cylinder.name=%s弯曲绕筒
-metaitem.tool.bending_cylinder_small.name=小型%s弯曲绕筒
+# Air Collector
+gregtech.machine.air_collector.ev.name=进阶空气收集器 III
+gtadditions.machine.air_collector.iv.name=大气收集器
+gtadditions.machine.air_collector.luv.name=大气收集器 II
 
-recipemap.cluster_mill.name=多辊式轧机
-recipemap.circuit_assembler.name=电路组装机
-recipemap.coke_oven.name=工业焦炉
-recipemap.distill_tower.name=蒸馏塔
-recipemap.assembly_line.name=装配线
-recipemap.naquadah_reactor.name=硅岩反应堆燃料
-recipemap.replicator.name=复制机
-recipemap.mass_fab.name=质量发生器
-recipemap.cracker_unit.name=石油裂化机
-recipemap.bundler.name=Wire Bundling
+
+## Multiblocks
+
+# Plasma Turbine
 recipemap.plasma_generator.name=等离子涡轮燃料
 
-material.brick=砖
-material.fireclay=耐火粘土
-material.coke=焦煤
-material.phosphorous_pentoxide=五氧化二磷
-material.phosphoric_acid=磷酸
-material.polyvinyl_acetate=聚乙酸乙烯酯
-material.phenol=苯酚
-material.bisphenol_a=双酚A
-material.epoxid=环氧树脂
-material.reinforced_epoxy_resin=纤维强化的环氧树脂
-material.borosilicate_glass=硼硅玻璃
-material.polyvinyl_chloride=聚氯乙烯
-material.vinyl_chloride=氯乙烯
-material.ethylene=乙烯
-material.charcoal_byproducts=木炭副产
-material.benzene=苯
-material.wood_gas=木炭气
-material.wood_vinegar=木醋酸
-material.wood_tar=木焦油
-material.sodium_hydroxide=氢氧化钠
-material.quicklime=生石灰
-material.acetone=丙酮
-material.sulfur_trioxide=三氧化硫
-material.sulfur_dioxide=二氧化硫
-material.glycerol=甘油
-material.fish_oil=鱼油
-material.methanol=甲醇
-material.carbon_monoxide=一氧化碳
-material.nitro_fuel=高十六烷值柴油
-material.diluted_sulfuric_acid=稀硫酸
-material.sodium_bisulfate=硫酸氢钠
-material.chloroform=氯仿
-material.diluted_hydrochloric_acid=稀盐酸
-material.hypochlorous_acid=次氯酸
-material.ammonia=氨
-material.chloramine=氯胺
-material.dimethylamine=二甲胺
-material.dimethylhidrazine=偏二甲肼
-material.rocket_fuel=火箭燃料
-material.dinitrogen_tetroxide=四氧化二氮
-material.silicon_rubber=硅橡胶
-material.polydimethylsiloxane=聚二甲基硅氧烷
-material.dimethyldichlorosilane=二甲基氯硅烷
-material.styrene=苯乙烯
-material.polystyrene=聚苯乙烯
-material.butadiene=丁二烯
-material.raw_styrene_butadiene_rubber=生丁苯橡胶
-material.styrene_butadiene_rubber=丁苯橡胶
-material.dichlorobenzene=对二氯苯
-material.hydrochloric_acid=氢氯酸
-material.acetic_acid=乙酸
-material.fermented_biomass=发酵过的生物质
-material.potash=钾碱
-material.soda_ash=纯碱
-material.hydrofluoric_acid=氢氟酸
-material.nitric_oxide=一氧化氮
-material.methyl_acetate=乙酸甲酯
-material.ethenone=乙烯酮
-material.tetranitromethane=四硝基甲烷
-material.bio_diesel=生物柴油
-material.raw_growth_medium=培养基原液
-material.sterilized_growth_medium=无菌培养基
-material.meat=肉
-material.cooked_meat=熟肉
-material.vinyl_acetate=乙酸乙烯酯
-material.gallium_arsenide=砷化镓
-material.polyphenylene_sulfide=聚苯硫醚
-material.nickel_sulfate_water_solution=硫酸镍溶液
-material.blue_vitriol_water_solution=蓝矾溶液
-material.propane=丙烷
-material.propene=丙烯
-material.ethane=乙烷
-material.butene=丁烯
-material.butane=丁烷
-material.calcium_acetate=乙酸钙溶液
-material.cumene=异丙苯
-material.indium_gallium_phosphide=磷化铟镓
-material.platinum_group_sludge=铂系矿泥
-material.ferrite_mixture=铁氧体混合物
-material.nickel_zinc_ferrite=镍锌铁氧体
-material.indium_concentrate=铟富集溶液
-material.lead_zinc_solution=铅锌溶液
-material.tetrafluoroethylene=四氟乙烯
-material.salt_water=盐水
-material.hydrocracked_ethane=加氢裂化的乙烷
-material.hydrocracked_ethylene=加氢裂化的乙烯
-material.hydrocracked_propene=加氢裂化的丙烯
-material.hydrocracked_propane=加氢裂化的丙烷
-material.hydrocracked_light_fuel=加氢裂化的轻燃油
-material.hydrocracked_butane=加氢裂化的丁烷
-material.hydrocracked_naphtha=加氢裂化的石脑油
-material.hydrocracked_heavy_fuel=加氢裂化的重燃油
-material.hydrocracked_gas=加氢裂化的炼油气
-material.hydrocracked_butene=加氢裂化的丁烯
-material.hydrocracked_butadiene=加氢裂化的丁二烯
-material.steamcracked_ethane=蒸汽裂化的乙烷
-material.steamcracked_ethylene=蒸汽裂化的乙烯
-material.steamcracked_propene=蒸汽裂化的丙烯
-material.steamcracked_propane=蒸汽裂化的丙烷
-material.cracked_light_fuel=蒸汽裂化的轻燃油
-material.steamcracked_butane=蒸汽裂化的丁烷
-material.steamcracked_naphtha=蒸汽裂化的石脑油
-material.cracked_heavy_fuel=蒸汽裂化的重燃油
-material.steamcracked_gas=蒸汽裂化的炼油气
-material.steamcracked_butene=蒸汽裂化的丁烯
-material.steamcracked_butadiene=蒸汽裂化的丁二烯
-material.biogas=沼气
-material.chloromethane=氯甲烷
-material.allyl_chloride=烯丙基氯
-material.isoprene=异戊二烯
-material.massicot=铅黄
-material.antimony_trioxide=锑华
-material.zincite=红锌矿
-material.cobalt_oxide=氧化钴
-material.arsenic_trioxide=砒霜
-material.cupric_oxide=氧化铜
-material.ferrosilite=铁辉石
-material.magnesia=苦土
-material.ga_sodium_sulfide=硫化钠
-material.neutral_matter=中子流质
-material.positive_matter=质子流质
-material.neutronium=中子素
-material.plasma=等离子约束
-material.lignite_coke=褐焦煤
-
-item.epoxid.ingot=环氧树脂条
-item.epoxid.dustTiny=小撮环氧树脂末
-item.epoxid.dustSmall=小堆环氧树脂末
-item.epoxid.dust=环氧树脂末
-item.epoxid.nugget=环氧树脂颗粒
-item.epoxid.plateDense=致密环氧树脂片
-item.epoxid.plate=环氧树脂片
-item.epoxid.foil=薄环氧树脂片
-item.reinforced_epoxy_resin.ingot=纤维强化的环氧树脂条
-item.reinforced_epoxy_resin.dustTiny=小撮纤维强化的环氧树脂末
-item.reinforced_epoxy_resin.dustSmall=小堆纤维强化的环氧树脂末
-item.reinforced_epoxy_resin.dust=纤维强化的环氧树脂末
-item.reinforced_epoxy_resin.nugget=纤维强化的环氧树脂颗粒
-item.reinforced_epoxy_resin.plateDense=致密纤维强化的环氧树脂片
-item.reinforced_epoxy_resin.plate=纤维强化的环氧树脂片
-item.reinforced_epoxy_resin.foil=薄纤维强化的环氧树脂片
-item.borosilicate_glass.ingot=硼硅玻璃条
-item.borosilicate_glass.dustTiny=小撮硼硅玻璃末
-item.borosilicate_glass.dustSmall=小堆硼硅玻璃末
-item.borosilicate_glass.dust=硼硅玻璃末
-item.borosilicate_glass.nugget=硼硅玻璃颗粒
-item.borosilicate_glass.plateDense=致密硼硅玻璃片
-item.borosilicate_glass.plate=硼硅玻璃片
-item.borosilicate_glass.foil=薄硼硅玻璃片
-item.polyvinyl_chloride.ingot=聚氯乙烯条
-item.polyvinyl_chloride.dustTiny=小撮聚氯乙烯末
-item.polyvinyl_chloride.dustSmall=小堆聚氯乙烯末
-item.polyvinyl_chloride.dust=聚氯乙烯末
-item.polyvinyl_chloride.nugget=聚氯乙烯颗粒
-item.polyvinyl_chloride.plateDense=致密聚氯乙烯片
-item.polyvinyl_chloride.plate=聚氯乙烯片
-item.polyvinyl_chloride.foil=薄聚氯乙烯片
-item.silicone_rubber.ingot=硅橡胶条
-item.silicone_rubber.dustTiny=小撮硅橡胶末
-item.silicone_rubber.dustSmall=小堆硅橡胶末
-item.silicone_rubber.dust=硅橡胶末
-item.silicone_rubber.nugget=硅橡胶颗粒
-item.silicone_rubber.plateDense=致密硅橡胶片
-item.silicone_rubber.plate=硅橡胶片
-item.silicone_rubber.foil=薄硅橡胶片
-item.polystyrene.ingot=聚苯乙烯条
-item.polystyrene.dustTiny=小撮聚苯乙烯末
-item.polystyrene.dustSmall=小堆聚苯乙烯末
-item.polystyrene.dust=聚苯乙烯末
-item.polystyrene.nugget=聚苯乙烯颗粒
-item.polystyrene.plateDense=致密聚苯乙烯片
-item.polystyrene.plate=聚苯乙烯片
-item.polystyrene.foil=薄聚苯乙烯片
-item.styrene_butadiene_rubber.ingot=丁苯橡胶条
-item.styrene_butadiene_rubber.dustTiny=小撮丁苯橡胶末
-item.styrene_butadiene_rubber.dustSmall=小堆丁苯橡胶末
-item.styrene_butadiene_rubber.dust=丁苯橡胶末
-item.styrene_butadiene_rubber.nugget=丁苯橡胶颗粒
-item.styrene_butadiene_rubber.plateDense=致密丁苯橡胶片
-item.styrene_butadiene_rubber.plate=丁苯橡胶片
-item.styrene_butadiene_rubber.foil=薄丁苯橡胶片
-item.meat.dustTiny=小撮肉末
-item.meat.dustSmall=小堆肉末
-item.meat.dust=肉末
-
-gregtech.multiblock.coke_oven.description=焦炉是一台用来炼焦的多方块机器。它可以将煤炼成焦煤，褐煤炼成褐焦煤，原木炼成木炭，并同时伴有杂酚油作为副产物。
-gregtech.multiblock.assembly_line.description=装配线是一台大型多方块机器，包含有5到16片相似的重复结构。从理论上来讲，它是一个可以生产高级元件的大型的组装机。
-gregtech.multiblock.distill_tower.description=GA蒸馏塔是一台多方块机器，高度2到12层。它可以用来蒸馏液体，与蒸馏室不同的是，它可以一次性蒸馏出多种产物，并分别从每一层输出。
+# Fusion Reactor
+gtadditions.machine.fusion_reactor.luv.name=核聚变反应堆控制电脑 Mk I
+gtadditions.machine.fusion_reactor.zpm.name=核聚变反应堆控制电脑 Mk II
+gtadditions.machine.fusion_reactor.uv.name=核聚变反应堆控制电脑 Mk III
 gregtech.multiblock.fusion_reactor_mk1.description=核聚变反应堆 Mk I 是一台可以通过聚变生产重元素的大型多方块机器。它可以使用LuV，ZPM或者UV等级的能源仓。每一个能源仓可以增加10MEU的能量缓存。
 gregtech.multiblock.fusion_reactor_mk2.description=核聚变反应堆 Mk II 是一台可以通过聚变生产重元素的大型多方块机器。它可以使用ZPM或者UV等级的能源仓。每一个能源仓可以增加20MEU的能量缓存。
 gregtech.multiblock.fusion_reactor_mk3.description=核聚变反应堆 Mk III 是一台可以通过聚变生产重元素的大型多方块机器。它只能使用UV等级的能源仓。每一个能源仓可以增加40MEU的能量缓存。
 gregtech.multiblock.fusion_reactor.heat=热力: %d
 
+# Processing Array
+recipemap.processing_array.name=Processing Array
+gtadditions.machine.processing_array.name=Processing Array
+gregtech.multiblock.processing_array.description=The Processing Array combines up to 16 single block machines in a single multiblock, effectively easing automation.
+
+# Assembly Line
+recipemap.assembly_line.name=装配线
+gtadditions.machine.assembly_line.name=装配线
+gregtech.multiblock.assembly_line.description=装配线是一台大型多方块机器，包含有5到16片相似的重复结构。从理论上来讲，它是一个可以生产高级元件的大型的组装机。
+
+
+## Tools
+metaitem.tool.bending_cylinder.name=%s弯曲绕筒
+metaitem.tool.bending_cylinder_small.name=小型%s弯曲绕筒
+
+
+## Materials
 item.material.oreprefix.plateCurved=弯曲%s板
-item.material.oreprefix.ingotDouble=双重%s锭
-item.material.oreprefix.pipeGaSmall=小型%s管道
-item.material.oreprefix.pipeGa=中型%s管道
-item.material.oreprefix.pipeGaLarge=大型%s管道
+material.fish_oil=鱼油
+material.meat=肉
+material.neutral_matter=中子流质
+material.positive_matter=质子流质
+material.neutronium=中子素
+material.lignite_coke=褐焦煤
+material.coke=焦煤
 
-metaitem.circuit.parts.advanced.name=微型处理器
-metaitem.circuit.parts.advanced.tooltip=一个基础的电路板
-metaitem.circuit.integrated.name=编程电路
-metaitem.circuit.basic.name=集成逻辑电路
-metaitem.circuit.basic.tooltip=一个基础的电路板
-metaitem.circuit.advanced.name=集成处理器
-metaitem.circuit.advanced.tooltip=一个不错的电路板
-metaitem.circuit.master.name=晶体处理器集群
-metaitem.circuit.master.tooltip=一个大师级电路板
-metaitem.circuit.elite.name=量子处理器集群
-metaitem.circuit.elite.tooltip=一个精英电路板
-metaitem.circuit.data.name=工作站
-metaitem.circuit.data.tooltip=一个高级电路板
-metaitem.circuit.board.elite.name=神经元处理器
-metaitem.circuit.board.elite.tooltip=神经元CPU
-metaitem.credit.darmstadtium.name=中子素币
 
-metaitem.rubber_drop.name=粘性树脂
+## Crates and Drums
+gtadditions.machine.drum.wood.name=木桶
+gtadditions.machine.drum.bronze.name=青铜桶
+gtadditions.machine.drum.steel.name=钢桶
+gtadditions.machine.drum.stainless_steel.name=不锈钢桶
+gtadditions.machine.drum.titanium.name=钛桶
+gtadditions.machine.drum.tungstensteel.name=钨钢桶
 
-tile.metal_casing.primitive_bricks.name=耐火砖
-gregtech.machine.primitive_blast_furnace.bronze.tooltip=结构：3x3x4（宽x长x高）/n结构整体由耐火砖构成（共计32块）。/n第一层为3x3的方形结构。/n第二、三、四层为3x3的中空方形结构。/n本控制器方块放置于第二层的任一侧面的中间。/n在满足上述结构要求的基础之上，高炉之间可以共享方块。
+gtadditions.machine.crate.wood.name=木板条箱
+gtadditions.machine.crate.bronze.name=青铜板条箱
+gtadditions.machine.crate.steel.name=钢板条箱
+gtadditions.machine.crate.stainless_steel.name=不锈钢板条箱
+gtadditions.machine.crate.titanium.name=钛板条箱
+gtadditions.machine.crate.tungstensteel.name=钨钢板条箱
 
-gregtech.machine.drum.wood.name=木桶
-gregtech.machine.drum.bronze.name=青铜桶
-gregtech.machine.drum.steel.name=钢桶
-gregtech.machine.drum.stainless_steel.name=不锈钢桶
-gregtech.machine.drum.titanium.name=钛桶
-gregtech.machine.drum.tungstensteel.name=钨钢桶
 
-gregtech.machine.crate.wood.name=木板条箱
-gregtech.machine.crate.bronze.name=青铜板条箱
-gregtech.machine.crate.steel.name=钢板条箱
-gregtech.machine.crate.stainless_steel.name=不锈钢板条箱
-gregtech.machine.crate.titanium.name=钛板条箱
-gregtech.machine.crate.tungstensteel.name=钨钢板条箱
+## Forestry Integration
 
-fluid.tile.water=水
-fluid.tile.lava=岩浆
-
+# Combs
 item.gtadditions:comb.lignite.name=褐煤蜂窝
 item.gtadditions:comb.coal.name=煤蜂窝
 item.gtadditions:comb.rubbery.name=粘性蜂窝
@@ -724,35 +565,184 @@ item.gtadditions:comb.quantaria.name=量子蜂窝
 item.gtadditions:comb.urania.name=铀蜂窝
 item.gtadditions:comb.plutonium.name=钚蜂窝
 item.gtadditions:comb.stargatium.name=硅岩蜂窝
+
+# Bees
 for.bees.species.slime=史莱姆
 for.bees.species.lignite=褐煤
 for.bees.species.rubber=橡胶
-for.bees.species.coal=煤
-for.bees.species.oill=石油
-for.bees.species.redstone=红石
-for.bees.species.lapis=青金石
-for.bees.species.certus=赛特斯
-for.bees.species.ruby=红宝石
-for.bees.species.sapphire=蓝宝石
-for.bees.species.diamond=钻石
-for.bees.species.olivine=橄榄石
-for.bees.species.emerald=绿宝石
-for.bees.species.copper=铜
-for.bees.species.tin=锡
-for.bees.species.lead=铅
-for.bees.species.iron=铁
-for.bees.species.steel=钢
-for.bees.species.nickel=镍
-for.bees.species.zinc=锌
-for.bees.species.silver=银
-for.bees.species.gold=金
-for.bees.species.aluminium=铝
-for.bees.species.titanium=钛
-for.bees.species.chrome=铬
-for.bees.species.manganese=锰
-for.bees.species.tungsten=钨
-for.bees.species.platinum=铂
-for.bees.species.iridium=铱
-for.bees.species.uranium=铀
-for.bees.species.plutonium=钚
-for.bees.species.naquadah=硅岩
+
+# Electrodes
+metaitem.electrode.apatite.name=Apatine Electrode
+metaitem.electrode.blaze.name=Blazing Electrode
+metaitem.electrode.bronze.name=Bronze Electrode
+metaitem.electrode.copper.name=Copper Electrode
+metaitem.electrode.diamond.name=Diamantine Electrode
+metaitem.electrode.emerald.name=Emerald Electrode
+metaitem.electrode.ender.name=Ender Electrode
+metaitem.electrode.gold.name=Golden Electrode
+metaitem.electrode.iron.name=Iron Electrode
+metaitem.electrode.lapis.name=Lapis Electrode
+metaitem.electrode.obsidian.name=Obsidian Electrode
+metaitem.electrode.orchid.name=Orchid Electrode
+metaitem.electrode.rubber.name=Rubberised Electrode
+metaitem.electrode.tin.name=Tin Electrode
+
+
+## Tinker's Construct Integration
+
+material.aluminium.name=Aluminium
+material.chrome.name=Chrome
+material.iridium.name=Iridium
+material.manganese.name=Manganese
+material.molybdenum.name=Molybdenum
+material.neodymium.name=Neodymium
+material.darmstadtium.name=Darmstadtium
+material.osmium.name=Osmium
+material.palladium.name=Palladium
+material.thorium.name=Thorium
+material.titanium.name=Titanium
+material.tungsten.name=Tungsten
+material.uranium.name=Uranium
+material.uranium235.name=Uranium-235
+material.brass.name=Brass
+material.invar.name=Invar
+material.magnalium.name=Magnalium
+material.stainless_steel.name=Stainless Steel
+material.ultimet.name=Ultimet
+material.wrought_iron.name=Wrought Iron
+material.osmiridium.name=Osmiridium
+material.sterling_silver.name=Sterling Siver
+material.rose_gold.name=Rose Gold
+material.black_bronze.name=Black Bronze
+material.bismuth_bronze.name=Bismuth Bronze
+material.black_steel.name=Black Steel
+material.red_steel.name=Red Steel
+material.blue_steel.name=Blue Steel
+material.damascus_steel.name=Damascus Steel
+material.tungsten_steel.name=Tungstensteel
+material.cobalt_brass.name=Cobalt Brass
+material.tungsten_carbide.name=Tungsten Carbide
+material.vanadium_steel.name=Vanadiumsteel
+material.hssg.name=HSS-G
+material.hsse.name=HSS-E
+material.hsss.name=HSS-S
+material.naquadah.name=Naquadah
+material.naquadah_alloy.name=Naquadah Alloy
+material.naquadah_enriched.name=Enriched Naquadah
+material.tritanium.name=Tritanium
+material.duranium.name=Duranium
+material.enderium.name=Enderium
+material.neutronium.name=Neutronium
+material.blue_topaz.name=Blue Topaz
+material.diamond.name=Diamond
+material.emerald.name=Emerald
+material.green_sapphire.name=Green Sapphire
+material.ruby.name=Ruby
+material.sapphire.name=Sapphire
+material.tanzanite.name=Tanzanite
+material.topaz.name=Topaz
+material.olivine.name=Olivine
+material.opal.name=Opal
+material.amethyst.name=Amethyst
+material.garnet_red.name=Red Garnet
+material.garnet_yellow.name=Yellow Garnet
+material.vinteum.name=Vinteum
+
+
+# Conflicts between SoG and GTCE lang file
+
+# Either accept the GTCE name and delete the conflict comment, or PR GTCE to update the translation
+# and then delete the conflict comment
+
+# GTCE: for.bees.species.coal=煤炭
+# SoG: for.bees.species.coal=煤
+
+# GTCE: for.bees.species.certus=下界石英
+# SoG: for.bees.species.certus=赛特斯
+
+# GTCE: gregtech.machine.primitive_blast_furnace.bronze.tooltip=结构: 3x3x4 (WxLxH) 整个结构由耐火砖组成(总共 32 块)./n第一层是一个 3x3 正方形./n第二三四层中间没有方块./n土高炉方块位于第二层任意一侧的中间./n没有高炉主体的侧面可以共享.
+# SoG: gregtech.machine.primitive_blast_furnace.bronze.tooltip=结构：3x3x4（宽x长x高）/n结构整体由耐火砖构成（共计32块）。/n第一层为3x3的方形结构。/n第二、三、四层为3x3的中空方形结构。/n本控制器方块放置于第二层的任一侧面的中间。/n在满足上述结构要求的基础之上，高炉之间可以共享方块。
+
+# GTCE: metaitem.rubber_drop.name=橡胶
+# SoG: metaitem.rubber_drop.name=粘性树脂
+
+# GTCE: metaitem.board.coated.name=覆膜电基板
+# SoG: metaitem.board.coated.name=覆膜电路基板
+
+# GTCE: metaitem.board.plastic.name=塑料基板
+# SoG: metaitem.board.plastic.name=塑料电路板基板
+
+# GTCE: metaitem.brick.fireclay.name=耐火砖块
+# SoG: metaitem.brick.fireclay.name=耐火砖
+
+# GTCE: metaitem.circuit.advanced.name=高级电路板
+# SoG: metaitem.circuit.advanced.name=进阶电路板
+
+# GTCE: metaitem.compressed.fireclay.name=压缩粘土
+# SOG: metaitem.compressed.fireclay.name=耐火砖坯
+
+# GTCE: metaitem.plate.nano_central_processing_unit.name=纳米CPU晶元
+# SoG: metaitem.plate.nano_central_processing_unit.name=纳米CPU
+
+# GTCE: metaitem.plate.nano_central_processing_unit.tooltip=纳米级中央处理器
+# SoG: metaitem.plate.nano_central_processing_unit.tooltip=功率电路
+
+# GTCE: metaitem.plate.random_access_memory.tooltip=随机存取存储器
+# SoG: metaitem.plate.random_access_memory.tooltip=集成电路
+
+# GTCE: metaitem.circuit.crystal_processor.tooltip=借晶体蚀刻之便
+# SoG: metaitem.circuit.crystal_processor.tooltip=一个精英电路板
+
+# GTCE: metaitem.circuit.nano_processor.tooltip=比以往更小
+# SoG: metaitem.circuit.nano_processor.tooltip=一个进阶电路板
+
+# GTCE: metaitem.circuit.quantum_processor.tooltip=将量子计算带入现实!
+# SoG: metaitem.circuit.quantum_processor.tooltip=一个高级电路板
+
+# GTCE: metaitem.circuit.wetware_processor.tooltip=你感到湿件处理器在看着你
+# SoG: metaitem.circuit.wetware_processor.tooltip=一个大师级电路板
+
+# GTCE: metaitem.carbon.fibers.name=粗制碳网
+# SoG: metaitem.carbon.fibers.name=碳纤维
+
+# GTCE: metaitem.crystal.central_processing_unit.name=晶体CPU
+# SoG: metaitem.crystal.central_processing_unit.name=晶体处理器
+
+# GTCE: metaitem.neutron_reflector=中子反射板
+# SoG: metaitem.neutron.reflector.name=中子反射器
+
+# GTCE: material.fireclay=耐火砖
+# SoG: material.fireclay=耐火粘土
+
+# GTCE: material.borosilicate_glass=硼玻璃
+# SoG: material.borosilicate_glass=硼硅玻璃
+
+# GTCE: material.vinyl_chloride=乙酸乙烯酯
+# SoG: material.vinyl_chloride=氯乙烯
+
+# GTCE: material.ethenone=Ethenone
+# SoG: material.ethenone=乙烯酮
+
+# GTCE: material.raw_growth_medium=粗培养基
+# SOG: material.raw_growth_medium=培养基原液
+
+# GTCE: material.hydrocracked_light_fuel=加氢裂化的轻燃料
+# SoG: material.hydrocracked_light_fuel=加氢裂化的轻燃油
+
+# GTCE: material.cracked_light_fuel=蒸汽裂化的轻燃料
+# SoG: material.cracked_light_fuel=蒸汽裂化的轻燃油
+
+# GTCE: material.cracked_heavy_fuel=蒸汽裂化的重燃料
+# SoG: material.cracked_heavy_fuel=蒸汽裂化的重燃油
+
+# GTCE: material.antimony_trioxide=三氧化二锑
+# SoG: material.antimony_trioxide=锑华
+
+# GTCE: gregtech.multiblock.coke_oven.description=焦炉是一种用来在游戏前期获取焦煤和杂酚油的多方块结构. 它不需要燃料且有32000mb杂酚油的液体内存. 可以通过焦炉仓访问内部库存.
+# SoG: gregtech.multiblock.coke_oven.description=焦炉是一台用来炼焦的多方块机器。它可以将煤炼成焦煤，褐煤炼成褐焦煤，原木炼成木炭，并同时伴有杂酚油作为副产物。
+
+# GTCE: for.bees.species.coal=煤炭
+# SoG: for.bees.species.coal=煤
+
+# GTCE: for.bees.species.certus=下界石英
+# SOG: for.bees.species.certus=赛特斯


### PR DESCRIPTION
Refactors and Cleans up the lang file, removing entries that are no longer applicable or the exact same as in GTCE. In addition, organizes the lang file into groups for easy navigation.

Note on Machine names: I have refactored the machine names to use a new system:
LV tier machine: Basic
MV-IV tier machine: Advanced
LuV-UV tier machine: Elite

This system is applied to most every machine, with a few exceptions being those that were renamed in GTCE in the MV-EV tier.
Personally, I think the wacky naming that existed for higher tier machines was annoying and confusing, which is the main cause of the machine name changes. However, I am open to changing some of the machine names back to their previous naming style, per some discussion.

Note 2. Once the `en-us` file is finalized and approved, I plan on copying the changes over to the `ru-ru` and `zh_cn` lang files, while keeping any existing translations for relevant lang entries, to make it easy to see what entries are missing localization and to organize those files. I would like to do those changes in this same PR.