### PR TITLE
Fix untextured Breaking particles for Crate and Drum

### DIFF
--- a/src/main/java/gregicadditions/machines/TileEntityCrate.java
+++ b/src/main/java/gregicadditions/machines/TileEntityCrate.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
+import gregtech.api.recipes.ModHandler;
 import org.apache.commons.lang3.tuple.Pair;
 
 import codechicken.lib.colour.ColourRGBA;
@@ -16,7 +17,6 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.ModularUI.Builder;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
-import gregtech.api.render.Textures;
 import gregtech.api.unification.material.type.SolidMaterial;
 import gregtech.api.util.GTUtility;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -90,7 +90,16 @@ public class TileEntityCrate extends MetaTileEntity {
 	@Override
 	@SideOnly(Side.CLIENT)
 	public Pair<TextureAtlasSprite, Integer> getParticleTexture() {
-		return Pair.of(material.toString().contains("wood") ? Textures.WOODEN_CHEST.getParticleTexture() : ClientHandler.METAL_CRATE.getParticleTexture(), 16777215);
+		if(ModHandler.isMaterialWood(material)) {
+			return Pair.of(ClientHandler.WOODEN_CRATE.getParticleTexture(), getPaintingColor());
+		}
+		else {
+			int color = ColourRGBA.multiply(
+					GTUtility.convertRGBtoOpaqueRGBA_CL(material.materialRGB),
+					GTUtility.convertRGBtoOpaqueRGBA_CL(getPaintingColor()));
+			color = GTUtility.convertOpaqueRGBA_CLtoRGB(color);
+			return Pair.of(ClientHandler.METAL_CRATE.getParticleTexture(), color);
+		}
 	}
 
 	@Override

--- a/src/main/java/gregicadditions/machines/TileEntityDrum.java
+++ b/src/main/java/gregicadditions/machines/TileEntityDrum.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
+import gregtech.api.recipes.ModHandler;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -171,7 +172,16 @@ public class TileEntityDrum extends MetaTileEntity {
 	@Override
 	@SideOnly(Side.CLIENT)
 	public Pair<TextureAtlasSprite, Integer> getParticleTexture() {
-		return Pair.of(material.toString().contains("wood") ? ClientHandler.BARREL.getParticleTexture() : ClientHandler.DRUM.getParticleTexture(), 16777215);
+		if(ModHandler.isMaterialWood(material)) {
+			return Pair.of(ClientHandler.BARREL.getParticleTexture(), getPaintingColor());
+		}
+		else {
+			int color = ColourRGBA.multiply(
+					GTUtility.convertRGBtoOpaqueRGBA_CL(material.materialRGB),
+					GTUtility.convertRGBtoOpaqueRGBA_CL(getPaintingColor()));
+			color = GTUtility.convertOpaqueRGBA_CLtoRGB(color);
+			return Pair.of(ClientHandler.DRUM.getParticleTexture(), color);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Based on https://github.com/GregTechCE/GregTech/pull/1481 This PR applies the same fix to SoG's crates and drums to ensure that they have textured breaking particles.