### PR TITLE
Remove the buildcraft api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,9 +57,6 @@ repositories {
        url = "http://chickenbones.net/maven/"
     }
     maven {
-        url = "https://mod-buildcraft.com/maven/"
-    }
-    maven {
         name = "tterrag maven"
         setUrl("http://maven.tterrag.com/")
     }
@@ -73,7 +70,6 @@ dependencies {
     deobfCompile "codechicken:ChickenASM:1.12-+"
     deobfCompile "codechicken-lib-1-8:CodeChickenLib-1.12.2:3.2.3.357:universal"
     deobfCompile "forge-multipart-cbe:ForgeMultipart-1.12.2:2.6.2.83:universal"
-    deobfCompile "com.mod-buildcraft:buildcraft-api:+"
     deobfCompile "slimeknights.mantle:Mantle:1.12-1.3.3.42"
     deobfCompile "slimeknights:TConstruct:1.12.2-2.12.0.115"
     deobfCompile "team.chisel.ctm:CTM:MC1.12.2-1.0.2.31"


### PR DESCRIPTION
GTCE does not depend on the buildcraft API, and from a test that I did cleaning caches, deleting the buildcraft API, and then setting up again, there were no issues when missing the buildcraft api.