### PR TITLE
Make drum not have a "0" NBT tag after fully emptying.

### DIFF
--- a/src/main/java/gregicadditions/machines/TileEntityDrum.java
+++ b/src/main/java/gregicadditions/machines/TileEntityDrum.java
@@ -120,23 +120,8 @@ public class TileEntityDrum extends MetaTileEntity {
 	public ICapabilityProvider initItemStackCapabilities(ItemStack itemStack) {
 		return new FluidHandlerItemStack(itemStack, tankSize) {
 			@Override
-			public FluidStack drain(FluidStack resource, boolean doDrain) {
-				FluidStack drained = super.drain(resource, doDrain);
-				this.removeTagWhenEmptied(doDrain);
-				return drained;
-			}
-
-			@Override
-			public FluidStack drain(int maxDrain, boolean doDrain) {
-				FluidStack drained = super.drain(maxDrain, doDrain);
-				this.removeTagWhenEmptied(doDrain);
-				return drained;
-			}
-
-			public void removeTagWhenEmptied(boolean doDrain) {
-				if(doDrain && this.getFluid() == null) {
-					this.container.setTagCompound(null);
-				}
+			protected void setContainerToEmpty() {
+				this.container.setTagCompound(null);
 			}
 		};
 	}

--- a/src/main/java/gregicadditions/machines/TileEntityDrum.java
+++ b/src/main/java/gregicadditions/machines/TileEntityDrum.java
@@ -118,7 +118,27 @@ public class TileEntityDrum extends MetaTileEntity {
 
 	@Override
 	public ICapabilityProvider initItemStackCapabilities(ItemStack itemStack) {
-		return new FluidHandlerItemStack(itemStack, tankSize);
+		return new FluidHandlerItemStack(itemStack, tankSize) {
+			@Override
+			public FluidStack drain(FluidStack resource, boolean doDrain) {
+				FluidStack drained = super.drain(resource, doDrain);
+				this.removeTagWhenEmptied(doDrain);
+				return drained;
+			}
+
+			@Override
+			public FluidStack drain(int maxDrain, boolean doDrain) {
+				FluidStack drained = super.drain(maxDrain, doDrain);
+				this.removeTagWhenEmptied(doDrain);
+				return drained;
+			}
+
+			public void removeTagWhenEmptied(boolean doDrain) {
+				if(doDrain && this.getFluid() == null) {
+					this.container.setTagCompound(null);
+				}
+			}
+		};
 	}
 
 	@Override


### PR DESCRIPTION
Fixes drum having a "0" NBT tag after emptying the drum and picking it back up.