### PR TITLE
Fix Some Recipes Being Out of Reach of CraftTweaker

### DIFF
--- a/src/main/java/gregicadditions/GregicAdditions.java
+++ b/src/main/java/gregicadditions/GregicAdditions.java
@@ -76,8 +76,8 @@ public class GregicAdditions {
 
 	@EventHandler
 	public void postInit(FMLPostInitializationEvent event) {
-        if (!isForestryBeesDisabled())
-            proxy.postInit();
+		if (!isForestryBeesDisabled())
+			proxy.postInit();
 	}
 
 	@SubscribeEvent
@@ -92,9 +92,9 @@ public class GregicAdditions {
 		IForgeRegistry<Item> registry = event.getRegistry();
 		registry.register(createItemBlock(GAMetaBlocks.MUTLIBLOCK_CASING, VariantItemBlock::new));
 		registry.register(createItemBlock(GAMetaBlocks.TRANSPARENT_CASING, VariantItemBlock::new));
-        if (!isForestryBeesDisabled()) {
-            registry.register(GTCombs.combItem);
-        }
+		if (!isForestryBeesDisabled()) {
+			registry.register(GTCombs.combItem);
+		}
 	}
 
 	@SubscribeEvent(priority = EventPriority.LOW)
@@ -108,10 +108,10 @@ public class GregicAdditions {
 		GeneratorFuels.init();
 		GAMetaItems.registerOreDict();
 		GAMetaItems.registerRecipes();
-        GARecipeAddition.generatedRecipes();
-        if (!isForestryBeesDisabled()) {
-            GTMachineCombRecipes.init();
-        }
+		GARecipeAddition.generatedRecipes();
+		if (!isForestryBeesDisabled()) {
+			GTMachineCombRecipes.init();
+		}
 	}
 
 	private <T extends Block> ItemBlock createItemBlock(T block, Function<T, ItemBlock> producer) {

--- a/src/main/java/gregicadditions/GregicAdditions.java
+++ b/src/main/java/gregicadditions/GregicAdditions.java
@@ -38,7 +38,7 @@ import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.registries.IForgeRegistry;
 
-@Mod(modid = GregicAdditions.MODID, name = GregicAdditions.NAME, version = GregicAdditions.VERSION, dependencies = "required-after:gregtech@[1.14.0.689,);after:forestry;after:tconstruct")
+@Mod(modid = GregicAdditions.MODID, name = GregicAdditions.NAME, version = GregicAdditions.VERSION, dependencies = "required-after:gregtech@[1.14.0.689,);after:forestry;after:tconstruct;after:crafttweaker;")
 public class GregicAdditions {
 	public static final String MODID = "gtadditions";
 	public static final String NAME = "Shadows of Greg";
@@ -77,8 +77,8 @@ public class GregicAdditions {
 
 	@EventHandler
 	public void postInit(FMLPostInitializationEvent event) {
-		GARecipeAddition.generatedRecipes();
-		if (!isForestryBeesDisabled())
+
+		if (!isForestryBeesDisabled()) // TODO
 			proxy.postInit();
 	}
 
@@ -107,6 +107,7 @@ public class GregicAdditions {
 		GeneratorFuels.init();
 		GAMetaItems.registerOreDict();
 		GAMetaItems.registerRecipes();
+        GARecipeAddition.generatedRecipes();
 	}
 
 	private <T extends Block> ItemBlock createItemBlock(T block, Function<T, ItemBlock> producer) {

--- a/src/main/java/gregicadditions/GregicAdditions.java
+++ b/src/main/java/gregicadditions/GregicAdditions.java
@@ -5,12 +5,11 @@ import java.util.function.Function;
 import forestry.api.core.ForestryAPI;
 import forestry.core.config.Constants;
 import forestry.modules.ForestryModuleUids;
+import gregicadditions.bees.*;
 import net.minecraft.util.ResourceLocation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import gregicadditions.bees.CommonProxy;
-import gregicadditions.bees.GTBees;
 import gregicadditions.item.GAMetaBlocks;
 import gregicadditions.item.GAMetaItems;
 import gregicadditions.machines.GATileEntities;
@@ -38,7 +37,7 @@ import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.registries.IForgeRegistry;
 
-@Mod(modid = GregicAdditions.MODID, name = GregicAdditions.NAME, version = GregicAdditions.VERSION, dependencies = "required-after:gregtech@[1.14.0.689,);after:forestry;after:tconstruct;after:crafttweaker;")
+@Mod(modid = GregicAdditions.MODID, name = GregicAdditions.NAME, version = GregicAdditions.VERSION, dependencies = "required-after:gregtech@[1.14.0.689,);after:forestry;after:tconstruct;")
 public class GregicAdditions {
 	public static final String MODID = "gtadditions";
 	public static final String NAME = "Shadows of Greg";
@@ -77,9 +76,8 @@ public class GregicAdditions {
 
 	@EventHandler
 	public void postInit(FMLPostInitializationEvent event) {
-
-		if (!isForestryBeesDisabled()) // TODO
-			proxy.postInit();
+        if (!isForestryBeesDisabled())
+            proxy.postInit();
 	}
 
 	@SubscribeEvent
@@ -94,6 +92,9 @@ public class GregicAdditions {
 		IForgeRegistry<Item> registry = event.getRegistry();
 		registry.register(createItemBlock(GAMetaBlocks.MUTLIBLOCK_CASING, VariantItemBlock::new));
 		registry.register(createItemBlock(GAMetaBlocks.TRANSPARENT_CASING, VariantItemBlock::new));
+        if (!isForestryBeesDisabled()) {
+            registry.register(GTCombs.combItem);
+        }
 	}
 
 	@SubscribeEvent(priority = EventPriority.LOW)
@@ -108,6 +109,10 @@ public class GregicAdditions {
 		GAMetaItems.registerOreDict();
 		GAMetaItems.registerRecipes();
         GARecipeAddition.generatedRecipes();
+        if (!isForestryBeesDisabled()) {
+            GTMachineCombRecipes.init();
+            ForestryMachineRecipes.init();
+        }
 	}
 
 	private <T extends Block> ItemBlock createItemBlock(T block, Function<T, ItemBlock> producer) {

--- a/src/main/java/gregicadditions/GregicAdditions.java
+++ b/src/main/java/gregicadditions/GregicAdditions.java
@@ -111,7 +111,6 @@ public class GregicAdditions {
         GARecipeAddition.generatedRecipes();
         if (!isForestryBeesDisabled()) {
             GTMachineCombRecipes.init();
-            ForestryMachineRecipes.init();
         }
 	}
 

--- a/src/main/java/gregicadditions/bees/ClientProxy.java
+++ b/src/main/java/gregicadditions/bees/ClientProxy.java
@@ -24,6 +24,7 @@ public class ClientProxy extends CommonProxy {
 	public void postInit() {
 		ItemColors itemColors = Minecraft.getMinecraft().getItemColors();
 		itemColors.registerItemColorHandler(ColoredItemItemColor.INSTANCE, GTCombs.combItem);
+		super.postInit();
 	}
 
 	@SubscribeEvent

--- a/src/main/java/gregicadditions/bees/ClientProxy.java
+++ b/src/main/java/gregicadditions/bees/ClientProxy.java
@@ -19,16 +19,11 @@ import static gregicadditions.GregicAdditions.isForestryBeesDisabled;
 
 @Mod.EventBusSubscriber(Side.CLIENT)
 public class ClientProxy extends CommonProxy {
-	@Override
-	public void preInit() {
-		super.preInit();
-	}
 
 	@Override
 	public void postInit() {
 		ItemColors itemColors = Minecraft.getMinecraft().getItemColors();
 		itemColors.registerItemColorHandler(ColoredItemItemColor.INSTANCE, GTCombs.combItem);
-		super.postInit();
 	}
 
 	@SubscribeEvent

--- a/src/main/java/gregicadditions/bees/ClientProxy.java
+++ b/src/main/java/gregicadditions/bees/ClientProxy.java
@@ -2,7 +2,6 @@ package gregicadditions.bees;
 
 import forestry.api.core.ForestryAPI;
 import forestry.core.items.IColoredItem;
-import gregicadditions.GAConfig;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.color.IItemColor;
 import net.minecraft.client.renderer.color.ItemColors;

--- a/src/main/java/gregicadditions/bees/CommonProxy.java
+++ b/src/main/java/gregicadditions/bees/CommonProxy.java
@@ -1,73 +1,11 @@
 package gregicadditions.bees;
 
-import forestry.api.recipes.ICentrifugeRecipe;
-import forestry.api.recipes.ISqueezerRecipe;
-import forestry.api.recipes.RecipeManagers;
-import forestry.core.items.ItemFluidContainerForestry;
-import gregicadditions.GAConfig;
 import gregicadditions.GregicAdditions;
-import gregtech.api.recipes.Recipe;
-import gregtech.api.recipes.RecipeMaps;
-import gregtech.api.recipes.builders.SimpleRecipeBuilder;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.IRecipe;
-import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.common.eventhandler.EventPriority;
-import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import net.minecraftforge.registries.IForgeRegistry;
-
-import java.util.Collections;
-
-import static gregicadditions.GregicAdditions.isForestryBeesDisabled;
 
 @Mod.EventBusSubscriber(modid = GregicAdditions.MODID)
 public class CommonProxy {
 
-	public void preInit() {
-
-	}
-
 	public void postInit() {
-		if (GAConfig.GTBees.GenerateCentrifugeRecipes) for (ICentrifugeRecipe recipe : RecipeManagers.centrifugeManager.recipes()) {
-			SimpleRecipeBuilder builder = RecipeMaps.CENTRIFUGE_RECIPES.recipeBuilder();
-			builder.inputs(recipe.getInput().copy());
-			for (ItemStack stack : recipe.getAllProducts().keySet()) {
-				builder.chancedOutput(stack.copy(), (int) (recipe.getAllProducts().get(stack) * Recipe.getMaxChancedValue()), 1000);
-			}
-			builder.EUt(5);
-			builder.duration(128);
-			builder.buildAndRegister();
-		}
-
-		if (GAConfig.GTBees.GenerateExtractorRecipes) for (ISqueezerRecipe recipe : RecipeManagers.squeezerManager.recipes()) {
-			if (recipe.getResources().size() != 1 || recipe.getResources().get(0).getItem() instanceof ItemFluidContainerForestry) continue;
-			if (RecipeMaps.FLUID_EXTRACTION_RECIPES.findRecipe(Integer.MAX_VALUE, recipe.getResources(), Collections.emptyList(), Integer.MAX_VALUE) != null) continue;
-			SimpleRecipeBuilder builder = RecipeMaps.FLUID_EXTRACTION_RECIPES.recipeBuilder();
-			builder.inputs(recipe.getResources().get(0).copy());
-			if (!recipe.getRemnants().isEmpty()) builder.chancedOutput(recipe.getRemnants().copy(), (int) (recipe.getRemnantsChance() * Recipe.getMaxChancedValue()), 1000);
-			if (recipe.getFluidOutput() != null) builder.fluidOutputs(recipe.getFluidOutput());
-			builder.EUt(5);
-			builder.duration(128);
-			builder.buildAndRegister();
-		}
-
-		GTMachineRecipes.postInit();
-	}
-
-	@SubscribeEvent
-	public static void registerItems(RegistryEvent.Register<Item> event) {
-		if (isForestryBeesDisabled())
-			return;
-		IForgeRegistry<Item> registry = event.getRegistry();
-		registry.register(GTCombs.combItem);
-	}
-
-	@SubscribeEvent(priority = EventPriority.LOWEST)
-	public static void registerRecipes(RegistryEvent.Register<IRecipe> event) {
-		if (isForestryBeesDisabled())
-			return;
-		ForestryMachineRecipes.init();
 	}
 }

--- a/src/main/java/gregicadditions/bees/CommonProxy.java
+++ b/src/main/java/gregicadditions/bees/CommonProxy.java
@@ -7,6 +7,6 @@ import net.minecraftforge.fml.common.Mod;
 public class CommonProxy {
 
 	public void postInit() {
-        ForestryMachineRecipes.init();
+		ForestryMachineRecipes.init();
 	}
 }

--- a/src/main/java/gregicadditions/bees/CommonProxy.java
+++ b/src/main/java/gregicadditions/bees/CommonProxy.java
@@ -7,5 +7,6 @@ import net.minecraftforge.fml.common.Mod;
 public class CommonProxy {
 
 	public void postInit() {
+        ForestryMachineRecipes.init();
 	}
 }

--- a/src/main/java/gregicadditions/bees/ForestryMachineRecipes.java
+++ b/src/main/java/gregicadditions/bees/ForestryMachineRecipes.java
@@ -2,16 +2,50 @@ package gregicadditions.bees;
 
 import com.google.common.collect.ImmutableMap;
 
+import forestry.api.recipes.ICentrifugeRecipe;
+import forestry.api.recipes.ISqueezerRecipe;
 import forestry.api.recipes.RecipeManagers;
 import forestry.apiculture.ModuleApiculture;
 import forestry.core.ModuleCore;
+import forestry.core.items.ItemFluidContainerForestry;
+import gregicadditions.GAConfig;
+import gregtech.api.recipes.Recipe;
+import gregtech.api.recipes.RecipeMaps;
+import gregtech.api.recipes.builders.SimpleRecipeBuilder;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.common.items.MetaItems;
+import net.minecraft.item.ItemStack;
+
+import java.util.Collections;
 
 public class ForestryMachineRecipes {
 	public static void init() {
+
+        if (GAConfig.GTBees.GenerateCentrifugeRecipes) for (ICentrifugeRecipe recipe : RecipeManagers.centrifugeManager.recipes()) {
+            SimpleRecipeBuilder builder = RecipeMaps.CENTRIFUGE_RECIPES.recipeBuilder();
+            builder.inputs(recipe.getInput().copy());
+            for (ItemStack stack : recipe.getAllProducts().keySet()) {
+                builder.chancedOutput(stack.copy(), (int) (recipe.getAllProducts().get(stack) * Recipe.getMaxChancedValue()), 1000);
+            }
+            builder.EUt(5);
+            builder.duration(128);
+            builder.buildAndRegister();
+        }
+
+        if (GAConfig.GTBees.GenerateExtractorRecipes) for (ISqueezerRecipe recipe : RecipeManagers.squeezerManager.recipes()) {
+            if (recipe.getResources().size() != 1 || recipe.getResources().get(0).getItem() instanceof ItemFluidContainerForestry) continue;
+            if (RecipeMaps.FLUID_EXTRACTION_RECIPES.findRecipe(Integer.MAX_VALUE, recipe.getResources(), Collections.emptyList(), Integer.MAX_VALUE) != null) continue;
+            SimpleRecipeBuilder builder = RecipeMaps.FLUID_EXTRACTION_RECIPES.recipeBuilder();
+            builder.inputs(recipe.getResources().get(0).copy());
+            if (!recipe.getRemnants().isEmpty()) builder.chancedOutput(recipe.getRemnants().copy(), (int) (recipe.getRemnantsChance() * Recipe.getMaxChancedValue()), 1000);
+            if (recipe.getFluidOutput() != null) builder.fluidOutputs(recipe.getFluidOutput());
+            builder.EUt(5);
+            builder.duration(128);
+            builder.buildAndRegister();
+        }
+
 		RecipeManagers.centrifugeManager.addRecipe(20, ModuleApiculture.getItems().propolis.getItemStack(), ImmutableMap.of(MetaItems.RUBBER_DROP.getStackForm(), 1.0f));
 
 		//Combs

--- a/src/main/java/gregicadditions/bees/ForestryMachineRecipes.java
+++ b/src/main/java/gregicadditions/bees/ForestryMachineRecipes.java
@@ -23,28 +23,28 @@ import java.util.Collections;
 public class ForestryMachineRecipes {
 	public static void init() {
 
-        if (GAConfig.GTBees.GenerateCentrifugeRecipes) for (ICentrifugeRecipe recipe : RecipeManagers.centrifugeManager.recipes()) {
-            SimpleRecipeBuilder builder = RecipeMaps.CENTRIFUGE_RECIPES.recipeBuilder();
-            builder.inputs(recipe.getInput().copy());
-            for (ItemStack stack : recipe.getAllProducts().keySet()) {
-                builder.chancedOutput(stack.copy(), (int) (recipe.getAllProducts().get(stack) * Recipe.getMaxChancedValue()), 1000);
-            }
-            builder.EUt(5);
-            builder.duration(128);
-            builder.buildAndRegister();
-        }
+		if (GAConfig.GTBees.GenerateCentrifugeRecipes) for (ICentrifugeRecipe recipe : RecipeManagers.centrifugeManager.recipes()) {
+			SimpleRecipeBuilder builder = RecipeMaps.CENTRIFUGE_RECIPES.recipeBuilder();
+			builder.inputs(recipe.getInput().copy());
+			for (ItemStack stack : recipe.getAllProducts().keySet()) {
+				builder.chancedOutput(stack.copy(), (int) (recipe.getAllProducts().get(stack) * Recipe.getMaxChancedValue()), 1000);
+			}
+			builder.EUt(5);
+			builder.duration(128);
+			builder.buildAndRegister();
+		}
 
-        if (GAConfig.GTBees.GenerateExtractorRecipes) for (ISqueezerRecipe recipe : RecipeManagers.squeezerManager.recipes()) {
-            if (recipe.getResources().size() != 1 || recipe.getResources().get(0).getItem() instanceof ItemFluidContainerForestry) continue;
-            if (RecipeMaps.FLUID_EXTRACTION_RECIPES.findRecipe(Integer.MAX_VALUE, recipe.getResources(), Collections.emptyList(), Integer.MAX_VALUE) != null) continue;
-            SimpleRecipeBuilder builder = RecipeMaps.FLUID_EXTRACTION_RECIPES.recipeBuilder();
-            builder.inputs(recipe.getResources().get(0).copy());
-            if (!recipe.getRemnants().isEmpty()) builder.chancedOutput(recipe.getRemnants().copy(), (int) (recipe.getRemnantsChance() * Recipe.getMaxChancedValue()), 1000);
-            if (recipe.getFluidOutput() != null) builder.fluidOutputs(recipe.getFluidOutput());
-            builder.EUt(5);
-            builder.duration(128);
-            builder.buildAndRegister();
-        }
+		if (GAConfig.GTBees.GenerateExtractorRecipes) for (ISqueezerRecipe recipe : RecipeManagers.squeezerManager.recipes()) {
+			if (recipe.getResources().size() != 1 || recipe.getResources().get(0).getItem() instanceof ItemFluidContainerForestry) continue;
+			if (RecipeMaps.FLUID_EXTRACTION_RECIPES.findRecipe(Integer.MAX_VALUE, recipe.getResources(), Collections.emptyList(), Integer.MAX_VALUE) != null) continue;
+			SimpleRecipeBuilder builder = RecipeMaps.FLUID_EXTRACTION_RECIPES.recipeBuilder();
+			builder.inputs(recipe.getResources().get(0).copy());
+			if (!recipe.getRemnants().isEmpty()) builder.chancedOutput(recipe.getRemnants().copy(), (int) (recipe.getRemnantsChance() * Recipe.getMaxChancedValue()), 1000);
+			if (recipe.getFluidOutput() != null) builder.fluidOutputs(recipe.getFluidOutput());
+			builder.EUt(5);
+			builder.duration(128);
+			builder.buildAndRegister();
+		}
 
 		RecipeManagers.centrifugeManager.addRecipe(20, ModuleApiculture.getItems().propolis.getItemStack(), ImmutableMap.of(MetaItems.RUBBER_DROP.getStackForm(), 1.0f));
 

--- a/src/main/java/gregicadditions/bees/GTMachineCombRecipes.java
+++ b/src/main/java/gregicadditions/bees/GTMachineCombRecipes.java
@@ -1,47 +1,15 @@
 package gregicadditions.bees;
 
-import forestry.api.recipes.ICentrifugeRecipe;
-import forestry.api.recipes.ISqueezerRecipe;
-import forestry.api.recipes.RecipeManagers;
 import forestry.core.ModuleCore;
 import forestry.core.fluids.Fluids;
-import forestry.core.items.ItemFluidContainerForestry;
 import gregicadditions.GAConfig;
-import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMaps;
-import gregtech.api.recipes.builders.SimpleRecipeBuilder;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.ore.OrePrefix;
-import net.minecraft.item.ItemStack;
-
-import java.util.Collections;
 
 public class GTMachineCombRecipes {
 	public static void init() {
-
-        if (GAConfig.GTBees.GenerateCentrifugeRecipes) for (ICentrifugeRecipe recipe : RecipeManagers.centrifugeManager.recipes()) {
-            SimpleRecipeBuilder builder = RecipeMaps.CENTRIFUGE_RECIPES.recipeBuilder();
-            builder.inputs(recipe.getInput().copy());
-            for (ItemStack stack : recipe.getAllProducts().keySet()) {
-                builder.chancedOutput(stack.copy(), (int) (recipe.getAllProducts().get(stack) * Recipe.getMaxChancedValue()), 1000);
-            }
-            builder.EUt(5);
-            builder.duration(128);
-            builder.buildAndRegister();
-        }
-
-        if (GAConfig.GTBees.GenerateExtractorRecipes) for (ISqueezerRecipe recipe : RecipeManagers.squeezerManager.recipes()) {
-            if (recipe.getResources().size() != 1 || recipe.getResources().get(0).getItem() instanceof ItemFluidContainerForestry) continue;
-            if (RecipeMaps.FLUID_EXTRACTION_RECIPES.findRecipe(Integer.MAX_VALUE, recipe.getResources(), Collections.emptyList(), Integer.MAX_VALUE) != null) continue;
-            SimpleRecipeBuilder builder = RecipeMaps.FLUID_EXTRACTION_RECIPES.recipeBuilder();
-            builder.inputs(recipe.getResources().get(0).copy());
-            if (!recipe.getRemnants().isEmpty()) builder.chancedOutput(recipe.getRemnants().copy(), (int) (recipe.getRemnantsChance() * Recipe.getMaxChancedValue()), 1000);
-            if (recipe.getFluidOutput() != null) builder.fluidOutputs(recipe.getFluidOutput());
-            builder.EUt(5);
-            builder.duration(128);
-            builder.buildAndRegister();
-        }
 
 		//Impregnated Recipes
 		if (GAConfig.GTBees.AssemblerRecipes) {

--- a/src/main/java/gregicadditions/bees/GTMachineCombRecipes.java
+++ b/src/main/java/gregicadditions/bees/GTMachineCombRecipes.java
@@ -1,15 +1,48 @@
 package gregicadditions.bees;
 
+import forestry.api.recipes.ICentrifugeRecipe;
+import forestry.api.recipes.ISqueezerRecipe;
+import forestry.api.recipes.RecipeManagers;
 import forestry.core.ModuleCore;
 import forestry.core.fluids.Fluids;
+import forestry.core.items.ItemFluidContainerForestry;
 import gregicadditions.GAConfig;
+import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMaps;
+import gregtech.api.recipes.builders.SimpleRecipeBuilder;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.ore.OrePrefix;
+import net.minecraft.item.ItemStack;
 
-public class GTMachineRecipes {
-	public static void postInit() {
+import java.util.Collections;
+
+public class GTMachineCombRecipes {
+	public static void init() {
+
+        if (GAConfig.GTBees.GenerateCentrifugeRecipes) for (ICentrifugeRecipe recipe : RecipeManagers.centrifugeManager.recipes()) {
+            SimpleRecipeBuilder builder = RecipeMaps.CENTRIFUGE_RECIPES.recipeBuilder();
+            builder.inputs(recipe.getInput().copy());
+            for (ItemStack stack : recipe.getAllProducts().keySet()) {
+                builder.chancedOutput(stack.copy(), (int) (recipe.getAllProducts().get(stack) * Recipe.getMaxChancedValue()), 1000);
+            }
+            builder.EUt(5);
+            builder.duration(128);
+            builder.buildAndRegister();
+        }
+
+        if (GAConfig.GTBees.GenerateExtractorRecipes) for (ISqueezerRecipe recipe : RecipeManagers.squeezerManager.recipes()) {
+            if (recipe.getResources().size() != 1 || recipe.getResources().get(0).getItem() instanceof ItemFluidContainerForestry) continue;
+            if (RecipeMaps.FLUID_EXTRACTION_RECIPES.findRecipe(Integer.MAX_VALUE, recipe.getResources(), Collections.emptyList(), Integer.MAX_VALUE) != null) continue;
+            SimpleRecipeBuilder builder = RecipeMaps.FLUID_EXTRACTION_RECIPES.recipeBuilder();
+            builder.inputs(recipe.getResources().get(0).copy());
+            if (!recipe.getRemnants().isEmpty()) builder.chancedOutput(recipe.getRemnants().copy(), (int) (recipe.getRemnantsChance() * Recipe.getMaxChancedValue()), 1000);
+            if (recipe.getFluidOutput() != null) builder.fluidOutputs(recipe.getFluidOutput());
+            builder.EUt(5);
+            builder.duration(128);
+            builder.buildAndRegister();
+        }
+
 		//Impregnated Recipes
 		if (GAConfig.GTBees.AssemblerRecipes) {
 			RecipeMaps.ASSEMBLER_RECIPES.recipeBuilder().EUt(8).duration(16).circuitMeta(1).input(OrePrefix.log, Materials.Wood, 8).fluidInputs(Fluids.SEED_OIL.getFluid(250)).outputs(ModuleCore.getItems().impregnatedCasing.getItemStack()).buildAndRegister();


### PR DESCRIPTION
This PR restructures the loading order of the Forestry compat, as well as some autogenerated recipes (block compression, packer/unpacker, forge hammer, etc) which were all getting registered on the **postInit** event fire. Since there was some discussion on this in the [issue thread](https://github.com/Shadows-of-Fire/Shadows-of-Greg/issues/84) this PR is addressing, I will explain to the best of my knowledge how the recipe registration order behaves.

Following the `preInit` event, Recipe Registration Events under the name of `RegistryEvent.Register<IRecipe>` are fired. These events can be given priorities through the `@SubscribeEvent` annotation, but ultimately, *all* of these events will be fired before CraftTweaker scripts are run (excluding certain loaders, like `#loader gregtech`, which is run in `preInit`). All recipe registration is intended to be done in these events, after `preInit` and before `init`. While it is considered bad practice, if for whatever reason recipe generation *must* go after CraftTweaker, then it should be done as the very first thing on the `init` event firing.

Now for whatever reason, these recipes were being registered in the `postInit` event, which is barely in time for JEI to pick them up and put them in its own recipe registry, not to mention well after CraftTweaker has finished running through all of its scripts.

Here is a sample script that can be used to prove that the recipes from the original issue are being properly removed:

```less
import mods.gregtech.recipe.RecipeMap;

val compressor as RecipeMap = RecipeMap.getByName("compressor");
val reactor as RecipeMap = RecipeMap.getByName("chemical_reactor");

// 3x3 block compression recipe
compressor.findRecipe(2, [<minecraft:coal:0> * 9], [null]).remove();

// Comb chemical reactor recipe
reactor.findRecipe(24, [<gtadditions:comb:13> * 9, <ore:crushedSpodumene>.firstItem], [<fluid:water> * 1000]).remove();
```

With this PR, I also verified that all other recipes are reachable by CT, since I did not see any reason why they should be done after. I also restructured the proxy slightly, since much of it was unnecessary and was only spreading the code out making it harder to follow.

Closes #84