### PR TITLE
Update Gregtech to 1.14.1.705

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     deobfCompile "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.+"
     deobfCompile "mezz.jei:jei_1.12.2:+"
     deobfCompile "net.sengir.forestry:forestry_1.12.2:+"
-    deobfCompile "gregtechce:gregtech:1.12.2:1.14.0.689"
+    deobfCompile "gregtechce:gregtech:1.12.2:1.14.1.705"
     deobfCompile "codechicken:ChickenASM:1.12-+"
     deobfCompile "codechicken-lib-1-8:CodeChickenLib-1.12.2:3.2.3.357:universal"
     deobfCompile "forge-multipart-cbe:ForgeMultipart-1.12.2:2.6.2.83:universal"


### PR DESCRIPTION
Updates the Gregtech version. It looks like it should be a clean update on our end.