### PR TITLE
Remove Forge Multi Part

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,6 @@ dependencies {
     deobfCompile "gregtechce:gregtech:1.12.2:1.14.1.705"
     deobfCompile "codechicken:ChickenASM:1.12-+"
     deobfCompile "codechicken-lib-1-8:CodeChickenLib-1.12.2:3.2.3.357:universal"
-    deobfCompile "forge-multipart-cbe:ForgeMultipart-1.12.2:2.6.2.83:universal"
     deobfCompile "slimeknights.mantle:Mantle:1.12-1.3.3.42"
     deobfCompile "slimeknights:TConstruct:1.12.2-2.12.0.115"
     deobfCompile "team.chisel.ctm:CTM:MC1.12.2-1.0.2.31"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,6 @@
 ccl_version=3.1.6.339
 chickenasm_version=1.0.2.9
 jei_version=4.9.1.188
-multipart_version=2.4.2.58
 crafttweaker_version=1.12-4.1.8.9
 top_version=1.4.23-16
 gt_version=1.5.12.148


### PR DESCRIPTION
Removes FMP as a gradle dependency. We were not using this dependency at all, and in their last release, GTCE removed the legacy support that they had for FMP and removed it from their dependencies as well.