### PR TITLE
Fix an error being thrown from trying to register a comb under Forest…

### DIFF
--- a/src/main/java/gregicadditions/bees/GTCombItem.java
+++ b/src/main/java/gregicadditions/bees/GTCombItem.java
@@ -48,7 +48,6 @@ public class GTCombItem extends Item implements IColoredItem, IItemModelRegister
 	@SideOnly(Side.CLIENT)
 	@Override
 	public void registerModel(Item item, IModelManager manager) {
-		manager.registerItemModel(item, 0);
 		for (int i = 0; i < GTCombs.VALUES.length; i++) {
 			manager.registerItemModel(item, i, GregicAdditions.MODID, "comb");
 		}


### PR DESCRIPTION
…ry's domain

Previously when loading there would be a file not found error due to attempting to register a comb without specifying the GTAdditions mod id.

I am unsure if the removed registration was even needed, due to the fact that it would be registered within the for loop, with the correct mod id.