### PR TITLE
Make PA find recipe based off tier of machine, not energy input

### DIFF
--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -733,7 +733,7 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 			setMaxProgress(resultOverclock[1]);
 			this.recipeEUt = resultOverclock[0] * this.numberOfOperations;
 			this.fluidOutputs = GTUtility.copyFluidList(recipe.getFluidOutputs());
-			int tier = getMachineTierForRecipe(recipe);
+			int tier = Math.min(getMachineTierForRecipe(recipe), GTUtility.getTierByVoltage(voltageTier));
 			this.itemOutputs = GTUtility.copyStackList(recipe.getResultItemOutputs(getOutputInventory().getSlots(),
 			                                                                       random,
 			                                                                       tier));

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -464,8 +464,14 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 
 			MetaTileEntity mte = MachineItemBlock.getMetaTileEntity(machine);
 
-			//Find the voltage tier of the machine.
-			this.voltageTier = GTValues.V[((ITieredMetaTileEntity) mte).getTier()];
+			if(mte == null) {
+				this.voltageTier = 0;
+			}
+			else {
+				//Find the voltage tier of the machine.
+				this.voltageTier = GTValues.V[((ITieredMetaTileEntity) mte).getTier()];
+			}
+
 
 
 			this.machineItemStack = machine;

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -184,7 +184,7 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 				return null;
 			}
 
-			return this.recipeMap.findRecipe(maxVoltage, inputs, fluidInputs, this.getMinTankCapacity(this.getOutputTank()));
+			return this.recipeMap.findRecipe(this.voltageTier, inputs, fluidInputs, this.getMinTankCapacity(this.getOutputTank()));
 		}
 
 
@@ -461,6 +461,12 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 			ItemStack machine = controller.getAbilities(GACapabilities.PA_MACHINE_CONTAINER).get(0).getStackInSlot(0);
 
 			RecipeMap<?> rmap = findRecipeMapAndCheckValid(machine);
+
+			MetaTileEntity mte = MachineItemBlock.getMetaTileEntity(machine);
+
+			//Find the voltage tier of the machine.
+			this.voltageTier = GTValues.V[((ITieredMetaTileEntity) mte).getTier()];
+
 
 			this.machineItemStack = machine;
 			this.recipeMap = rmap;

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -184,7 +184,7 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 				return null;
 			}
 
-			return this.recipeMap.findRecipe(this.voltageTier, inputs, fluidInputs, this.getMinTankCapacity(this.getOutputTank()));
+			return this.recipeMap.findRecipe(Math.min(this.voltageTier, maxVoltage), inputs, fluidInputs, this.getMinTankCapacity(this.getOutputTank()));
 		}
 
 

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -635,12 +635,16 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 			//Update the stored machine stack and recipe map variables
 			findMachineStack();
 
+			// Cache the old fluid inputs
+			final FluidStack[] cachedLastFluids =
+				(lastFluidInputs == null) ? null : Arrays.copyOf(this.lastFluidInputs, lastFluidInputs.length);
+
 			//Check to see if the machine stack has changed first
 			//TODO Could this machine bus specific check be used in the combined code?
 			boolean machineDirty = checkRecipeInputsDirty(machineBus, importFluids);
 			if(machineDirty || forceRecipeRecheck) {
 				//Check if the machine that the PA is operating on has changed
-				//Is this check needed if machineDirty is true?
+				//TODO Is this check needed if machineDirty is true?
 				if(didMachinesChange(machineItemStack)) {
 					previousRecipe = null;
 					oldMachineStack = null;
@@ -662,6 +666,9 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 			oldMachineStack = null;
 			for (int i = 0; i < importInventory.size(); i++) {
 				IItemHandlerModifiable bus = importInventory.get(i);
+				// Restore the cached fluid inputs before each per-bus dirty check to prevent false negatives
+				lastFluidInputs =
+					(cachedLastFluids == null) ? null : Arrays.copyOf(cachedLastFluids, cachedLastFluids.length);
 				boolean dirty = checkRecipeInputsDirty(bus, importFluids, i);
 				if (dirty || forceRecipeRecheck) {
 					this.forceRecipeRecheck = false;

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -513,6 +513,30 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 				recipe.matches(true, importInventory, importFluids);
 		}
 
+		protected boolean setupAndConsumeRecipeInputs(Recipe recipe, int index) {
+			RecipeMapMultiblockController controller = (RecipeMapMultiblockController) metaTileEntity;
+			if (controller.checkRecipe(recipe, false)) {
+
+				int[] resultOverclock = calculateOverclock(recipe.getEUt(), recipe.getDuration());
+				int totalEUt = resultOverclock[0] * resultOverclock[1];
+				IItemHandlerModifiable importInventory = getInputBuses().get(index);
+				IItemHandlerModifiable exportInventory = getOutputInventory();
+				IMultipleTankHandler importFluids = getInputTank();
+				IMultipleTankHandler exportFluids = getOutputTank();
+				boolean setup = (totalEUt >= 0 ? getEnergyStored() >= (totalEUt > getEnergyCapacity() / 2 ? resultOverclock[0] : totalEUt) :
+					(getEnergyStored() - resultOverclock[0] <= getEnergyCapacity())) &&
+					MetaTileEntity.addItemsToItemHandler(exportInventory, true, recipe.getAllItemOutputs(exportInventory.getSlots())) &&
+					MetaTileEntity.addFluidsToFluidHandler(exportFluids, true, recipe.getFluidOutputs()) &&
+					recipe.matches(true, importInventory, importFluids);
+
+				if (setup) {
+					controller.checkRecipe(recipe, true);
+					return true;
+				}
+			}
+			return false;
+		}
+
 		/**
 		 * Will check if the previous machine stack and the current machine stack are different
 		 * @param newMachineStack - The current machine stack
@@ -685,32 +709,6 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 			}
 			return shouldRecheckRecipe;
 		}
-
-
-		protected boolean setupAndConsumeRecipeInputs(Recipe recipe, int index) {
-			RecipeMapMultiblockController controller = (RecipeMapMultiblockController) metaTileEntity;
-			if (controller.checkRecipe(recipe, false)) {
-
-				int[] resultOverclock = calculateOverclock(recipe.getEUt(), recipe.getDuration());
-				int totalEUt = resultOverclock[0] * resultOverclock[1];
-				IItemHandlerModifiable importInventory = getInputBuses().get(index);
-				IItemHandlerModifiable exportInventory = getOutputInventory();
-				IMultipleTankHandler importFluids = getInputTank();
-				IMultipleTankHandler exportFluids = getOutputTank();
-				boolean setup = (totalEUt >= 0 ? getEnergyStored() >= (totalEUt > getEnergyCapacity() / 2 ? resultOverclock[0] : totalEUt) :
-					(getEnergyStored() - resultOverclock[0] <= getEnergyCapacity())) &&
-					MetaTileEntity.addItemsToItemHandler(exportInventory, true, recipe.getAllItemOutputs(exportInventory.getSlots())) &&
-					MetaTileEntity.addFluidsToFluidHandler(exportFluids, true, recipe.getFluidOutputs()) &&
-					recipe.matches(true, importInventory, importFluids);
-
-				if (setup) {
-					controller.checkRecipe(recipe, true);
-					return true;
-				}
-			}
-			return false;
-		}
-
 
 		// ------------------------------- End Distinct Bus Logic ------------------------------------------------
 

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -464,7 +464,7 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 
 			MetaTileEntity mte = MachineItemBlock.getMetaTileEntity(machine);
 
-			if(mte == null) {
+			if(!(mte instanceof ITieredMetaTileEntity)) {
 				this.voltageTier = 0;
 			}
 			else {


### PR DESCRIPTION
Makes PA find a recipe based on the tier of machine used for the recipe, not the tier of the energy input. Should fix the PA performing chanced recipes based on the tier of energy input, instead of the tier of machine.