### PR TITLE
Fix crash by skipping registry of weird plank/slab recipes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,9 +55,11 @@ repositories {
         url = "https://maven.blamejared.com/"
     }
     maven {
-        url = "http://maven.ic2.player.to"
+        name "WynPrice's Curse Maven"
+        url "https://cursemaven.com"
     }
     maven {
+        name "CurseForge Maven API"
         url "https://minecraft.curseforge.com/api/maven"
     }
     maven {
@@ -72,7 +74,7 @@ repositories {
 dependencies {
     deobfCompile "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.+"
     deobfCompile "mezz.jei:jei_1.12.2:+"
-    deobfCompile "net.sengir.forestry:forestry_1.12.2:+"
+    deobfCompile "curse.maven:forestry-59751:2918418"
     deobfCompile "gregtechce:gregtech:1.12.2:1.17.0.764"
     deobfCompile "codechicken:ChickenASM:1.12-+"
     deobfCompile "codechicken-lib-1-8:CodeChickenLib-1.12.2:3.2.3.357:universal"

--- a/src/main/java/gregicadditions/recipes/GARecipeAddition.java
+++ b/src/main/java/gregicadditions/recipes/GARecipeAddition.java
@@ -716,7 +716,7 @@ public class GARecipeAddition {
 
 				// No ingredients
 				List<Ingredient> ingredients = recipe.getIngredients();
-				if(ingredients.size() <= 0)
+				if(ingredients.isEmpty())
 					continue;
 
 				// Recipe's own inputs are rejected

--- a/src/main/java/gregicadditions/recipes/GARecipeAddition.java
+++ b/src/main/java/gregicadditions/recipes/GARecipeAddition.java
@@ -713,32 +713,54 @@ public class GARecipeAddition {
 			if (recipe.getRecipeOutput().isEmpty()) continue;
 			for (int i : OreDictionary.getOreIDs(recipe.getRecipeOutput())) {
 
+				// First, skip all recipes we don't care about
+				final String odName = OreDictionary.getOreName(i);
+				final boolean isPlank = odName.equals("plankWood");
+				final boolean isSlab = odName.equals("slabWood");
+				if (!(isPlank || isSlab)) {
+					continue;
+				}
+
 				// Skip cursed recipes:
 
 				List<Ingredient> ingredients = recipe.getIngredients();
-				if(ingredients.isEmpty()) {
-					GTLog.logger.warn("Skipping recipe with no ingredients: {}", recipe.getRegistryName());
+				if (ingredients.isEmpty()) {
+					GTLog.logger.warn("Skipping plank/slab recipe with no ingredients: {}", recipe.getRegistryName());
 					continue;
 				}
 
 				ItemStack[] matchingStacks = ingredients.get(0).getMatchingStacks();
-				if(matchingStacks.length == 0) {
-					GTLog.logger.warn("Skipping recipe whose own inputs were rejected: {}}", recipe.getRegistryName());
+				if (matchingStacks.length == 0) {
+					GTLog.logger.warn("Skipping plank/slab recipe whose own inputs were rejected: {}}",
+					                  recipe.getRegistryName());
 					continue;
 				}
 
 				ItemStack matchingStack = matchingStacks[0];
 
-				if (OreDictionary.getOreName(i).equals("plankWood") && recipe.getIngredients().size() == 1 && recipe.getRecipeOutput().getCount() == 4) {
+				if (isPlank && recipe.getIngredients().size() == 1 && recipe.getRecipeOutput().getCount() == 4) {
 					if (GAConfig.GT5U.GeneratedSawingRecipes) {
 						ModHandler.removeRecipeByName(recipe.getRegistryName());
-						ModHandler.addShapelessRecipe("log_to_4_" + recipe.getRecipeOutput().toString(), GTUtility.copyAmount(4, recipe.getRecipeOutput()), matchingStack, ToolDictNames.craftingToolSaw);
-						ModHandler.addShapelessRecipe("log_to_2_" + recipe.getRecipeOutput().toString(), GTUtility.copyAmount(2, recipe.getRecipeOutput()), matchingStack);
+						ModHandler.addShapelessRecipe(String.format("log_to_4_%s", recipe.getRecipeOutput()),
+						                              GTUtility.copyAmount(4, recipe.getRecipeOutput()),
+						                              matchingStack,
+						                              ToolDictNames.craftingToolSaw);
+						ModHandler.addShapelessRecipe(String.format("log_to_2_%s", recipe.getRecipeOutput()),
+						                              GTUtility.copyAmount(2, recipe.getRecipeOutput()),
+						                              matchingStack);
 					}
-					RecipeMaps.CUTTER_RECIPES.recipeBuilder().duration(200).EUt(8).inputs(matchingStack).fluidInputs(Materials.Lubricant.getFluid(1)).outputs(GTUtility.copyAmount(6, recipe.getRecipeOutput()), OreDictUnifier.get(OrePrefix.dust, Materials.Wood, 2)).buildAndRegister();
+					RecipeMaps.CUTTER_RECIPES.recipeBuilder()
+					                         .inputs(matchingStack)
+					                         .fluidInputs(Materials.Lubricant.getFluid(1))
+					                         .outputs(GTUtility.copyAmount(6, recipe.getRecipeOutput()),
+					                                  OreDictUnifier.get(OrePrefix.dust, Materials.Wood, 2))
+					                         .duration(200).EUt(8).buildAndRegister();
 				}
-				if (OreDictionary.getOreName(i).equals("slabWood") && recipe.getRecipeOutput().getCount() == 6) {
-					RecipeMaps.CUTTER_RECIPES.recipeBuilder().duration(50).EUt(4).inputs(matchingStack).outputs(GTUtility.copyAmount(2, recipe.getRecipeOutput())).buildAndRegister();
+				if (isSlab && recipe.getRecipeOutput().getCount() == 6) {
+					RecipeMaps.CUTTER_RECIPES.recipeBuilder()
+					                         .inputs(matchingStack)
+					                         .outputs(GTUtility.copyAmount(2, recipe.getRecipeOutput()))
+					                         .duration(50).EUt(4).buildAndRegister();
 				}
 			}
 		}

--- a/src/main/java/gregicadditions/recipes/GARecipeAddition.java
+++ b/src/main/java/gregicadditions/recipes/GARecipeAddition.java
@@ -30,6 +30,7 @@ import gregtech.api.unification.material.type.Material;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.unification.stack.MaterialStack;
 import gregtech.api.unification.stack.UnificationEntry;
+import gregtech.api.util.GTLog;
 import gregtech.api.util.GTUtility;
 import gregtech.common.blocks.BlockMachineCasing;
 import gregtech.common.blocks.BlockMultiblockCasing.MultiblockCasingType;
@@ -714,15 +715,17 @@ public class GARecipeAddition {
 
 				// Skip cursed recipes:
 
-				// No ingredients
 				List<Ingredient> ingredients = recipe.getIngredients();
-				if(ingredients.isEmpty())
+				if(ingredients.isEmpty()) {
+					GTLog.logger.warn("Skipping recipe with no ingredients: {}", recipe.getRegistryName());
 					continue;
+				}
 
-				// Recipe's own inputs are rejected
 				ItemStack[] matchingStacks = ingredients.get(0).getMatchingStacks();
-				if(matchingStacks.length == 0)
+				if(matchingStacks.length == 0) {
+					GTLog.logger.warn("Skipping recipe whose own inputs were rejected: {}}", recipe.getRegistryName());
 					continue;
+				}
 
 				ItemStack matchingStack = matchingStacks[0];
 

--- a/src/main/java/gregicadditions/recipes/GARecipeAddition.java
+++ b/src/main/java/gregicadditions/recipes/GARecipeAddition.java
@@ -43,6 +43,7 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.oredict.OreDictionary;
@@ -710,16 +711,31 @@ public class GARecipeAddition {
 		for (IRecipe recipe : CraftingManager.REGISTRY) {
 			if (recipe.getRecipeOutput().isEmpty()) continue;
 			for (int i : OreDictionary.getOreIDs(recipe.getRecipeOutput())) {
+
+				// Skip cursed recipes:
+
+				// No ingredients
+				List<Ingredient> ingredients = recipe.getIngredients();
+				if(ingredients.size() <= 0)
+					continue;
+
+				// Recipe's own inputs are rejected
+				ItemStack[] matchingStacks = ingredients.get(0).getMatchingStacks();
+				if(matchingStacks.length == 0)
+					continue;
+
+				ItemStack matchingStack = matchingStacks[0];
+
 				if (OreDictionary.getOreName(i).equals("plankWood") && recipe.getIngredients().size() == 1 && recipe.getRecipeOutput().getCount() == 4) {
 					if (GAConfig.GT5U.GeneratedSawingRecipes) {
 						ModHandler.removeRecipeByName(recipe.getRegistryName());
-						ModHandler.addShapelessRecipe("log_to_4_" + recipe.getRecipeOutput().toString(), GTUtility.copyAmount(4, recipe.getRecipeOutput()), recipe.getIngredients().get(0).getMatchingStacks()[0], ToolDictNames.craftingToolSaw);
-						ModHandler.addShapelessRecipe("log_to_2_" + recipe.getRecipeOutput().toString(), GTUtility.copyAmount(2, recipe.getRecipeOutput()), recipe.getIngredients().get(0).getMatchingStacks()[0]);
+						ModHandler.addShapelessRecipe("log_to_4_" + recipe.getRecipeOutput().toString(), GTUtility.copyAmount(4, recipe.getRecipeOutput()), matchingStack, ToolDictNames.craftingToolSaw);
+						ModHandler.addShapelessRecipe("log_to_2_" + recipe.getRecipeOutput().toString(), GTUtility.copyAmount(2, recipe.getRecipeOutput()), matchingStack);
 					}
-					RecipeMaps.CUTTER_RECIPES.recipeBuilder().duration(200).EUt(8).inputs(recipe.getIngredients().get(0).getMatchingStacks()[0]).fluidInputs(Materials.Lubricant.getFluid(1)).outputs(GTUtility.copyAmount(6, recipe.getRecipeOutput()), OreDictUnifier.get(OrePrefix.dust, Materials.Wood, 2)).buildAndRegister();
+					RecipeMaps.CUTTER_RECIPES.recipeBuilder().duration(200).EUt(8).inputs(matchingStack).fluidInputs(Materials.Lubricant.getFluid(1)).outputs(GTUtility.copyAmount(6, recipe.getRecipeOutput()), OreDictUnifier.get(OrePrefix.dust, Materials.Wood, 2)).buildAndRegister();
 				}
 				if (OreDictionary.getOreName(i).equals("slabWood") && recipe.getRecipeOutput().getCount() == 6) {
-					RecipeMaps.CUTTER_RECIPES.recipeBuilder().duration(50).EUt(4).inputs(recipe.getIngredients().get(0).getMatchingStacks()[0]).outputs(GTUtility.copyAmount(2, recipe.getRecipeOutput())).buildAndRegister();
+					RecipeMaps.CUTTER_RECIPES.recipeBuilder().duration(50).EUt(4).inputs(matchingStack).outputs(GTUtility.copyAmount(2, recipe.getRecipeOutput())).buildAndRegister();
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #166 by not trying to generate saw or cutting machine versions of existing wood planks/slabs recipes when the original recipe has some unusual properties that causes a crash.

Logs a warning when skipping such a recipe with a brief note why and what the original recipe is named.