### PR TITLE
Fix TConstruct Invar Recipe

### DIFF
--- a/src/main/java/gregicadditions/tconstruct/TinkersMaterials.java
+++ b/src/main/java/gregicadditions/tconstruct/TinkersMaterials.java
@@ -115,11 +115,11 @@ public class TinkersMaterials {
 
 			TinkerRegistry.registerAlloy(gregtech.api.unification.material.Materials.TinAlloy.getFluid(2), gregtech.api.unification.material.Materials.Iron.getFluid(1), gregtech.api.unification.material.Materials.Tin.getFluid(1));
 
-			TinkerRegistry.registerAlloy(gregtech.api.unification.material.Materials.Invar.getFluid(3), gregtech.api.unification.material.Materials.Iron.getFluid(1), gregtech.api.unification.material.Materials.Nickel.getFluid(1));
+			TinkerRegistry.registerAlloy(gregtech.api.unification.material.Materials.Invar.getFluid(3), gregtech.api.unification.material.Materials.Iron.getFluid(2), gregtech.api.unification.material.Materials.Nickel.getFluid(1));
 
 			TinkerRegistry.registerAlloy(gregtech.api.unification.material.Materials.TinAlloy.getFluid(2), gregtech.api.unification.material.Materials.WroughtIron.getFluid(1), gregtech.api.unification.material.Materials.Tin.getFluid(1));
 
-			TinkerRegistry.registerAlloy(gregtech.api.unification.material.Materials.Invar.getFluid(3), gregtech.api.unification.material.Materials.WroughtIron.getFluid(1), gregtech.api.unification.material.Materials.Nickel.getFluid(1));
+			TinkerRegistry.registerAlloy(gregtech.api.unification.material.Materials.Invar.getFluid(3), gregtech.api.unification.material.Materials.WroughtIron.getFluid(2), gregtech.api.unification.material.Materials.Nickel.getFluid(1));
 
 			TinkerRegistry.registerAlloy(gregtech.api.unification.material.Materials.BatteryAlloy.getFluid(5), gregtech.api.unification.material.Materials.Lead.getFluid(4), gregtech.api.unification.material.Materials.Antimony.getFluid(1));
 


### PR DESCRIPTION
(sorry if I did something wrong)
Idea from #programgames/Gregblock-revamped/issues/32

> There are 2 basic recipes for turning molten iron and nickel into invar.
One is mixing 288 mb of iron with 144 mb of nickel to make 432 mb of invar. The other is alloying 1mb of iron and 1 mb of nickel in the smeltery for 3 mb of invar.
I think the smeltery alloying recipe is wrong and it should be 2 mb of iron?