### PR TITLE
Hide button to enable distinct mode when no item inputs

### DIFF
--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -96,25 +96,40 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 	protected void addDisplayText(List<ITextComponent> textList) {
 		super.addDisplayText(textList);
 
-		if(inputInventory.getSlots() > 0) {
-			ITextComponent buttonText = new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct");
-			buttonText.appendText(" ");
-			ITextComponent button = withButton((isDistinctInputBusMode ?
-					new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct.yes") :
-					new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct.no")), "distinct");
-			withHoverTextTranslate(button, "gtadditions.multiblock.processing_array.distinct.info");
-			buttonText.appendSibling(button);
-			textList.add(buttonText);
-			textList.add(new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct2", isDistinctInputBusMode ?
-					new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct.yes") :
-					new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct.no")));
+		// if the structure isn't formed, no need to add extra text
+		if(!isStructureFormed())
+			return;
+
+		final boolean isDistinctModeAvailable = inputInventory.getSlots() > 0;
+
+		// Display a clickable toggle button with accompanying hint text
+		if(isDistinctModeAvailable) {
+			final String modeTranslationKey = "gtadditions.multiblock.processing_array.distinct." +
+				(isDistinctInputBusMode ? "yes" : "no");
+			textList.add(makeDistinctModeToggleButton(modeTranslationKey));
+			textList.add(new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct2",
+			                                          new TextComponentTranslation(modeTranslationKey)));
 		}
-		else {
-			textList.add(new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct.no_bus"));
-		}
+		else
+			textList.add(makeDistinctModeUnavailableTextComponent());
+
 		if(this.recipeMapWorkable.isActive()) {
 			textList.add(new TextComponentTranslation("gtadditions.multiblock.processing_array.locked"));
 		}
+	}
+
+	private ITextComponent makeDistinctModeToggleButton(String translationKey) {
+		ITextComponent label = new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct");
+		ITextComponent modeButton = withButton(new TextComponentTranslation(translationKey), "distinct");
+		withHoverTextTranslate(modeButton, "gtadditions.multiblock.processing_array.distinct.info");
+		return label.appendText(" ").appendSibling(modeButton);
+	}
+
+	private ITextComponent makeDistinctModeUnavailableTextComponent() {
+		ITextComponent label = new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct");
+		ITextComponent modeText = new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct.disabled");
+		withHoverTextTranslate(modeText, "gtadditions.multiblock.processing_array.distinct.no_bus");
+		return label.appendText(" ").appendSibling(modeText);
 	}
 
 	@Override

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -570,7 +570,9 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 
 		@Override
 		protected void trySearchNewRecipe() {
-			if(metaTileEntity instanceof TileEntityProcessingArray && ((TileEntityProcessingArray) metaTileEntity).isDistinctInputBusMode) {
+			if(metaTileEntity instanceof TileEntityProcessingArray &&
+			   getInputInventory().getSlots() > 0 &&
+			   ((TileEntityProcessingArray) metaTileEntity).isDistinctInputBusMode) {
 				trySearchNewRecipeDistinct();
 			}
 			else {

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -96,17 +96,22 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 	protected void addDisplayText(List<ITextComponent> textList) {
 		super.addDisplayText(textList);
 
-		ITextComponent buttonText = new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct");
-		buttonText.appendText(" ");
-		ITextComponent button = withButton((isDistinctInputBusMode ?
-			new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct.yes") :
-			new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct.no")), "distinct");
-		withHoverTextTranslate(button, "gtadditions.multiblock.processing_array.distinct.info");
-		buttonText.appendSibling(button);
-		textList.add(buttonText);
-		textList.add(new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct2", isDistinctInputBusMode ?
-			new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct.yes") :
-			new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct.no")));
+		if(inputInventory.getSlots() > 0) {
+			ITextComponent buttonText = new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct");
+			buttonText.appendText(" ");
+			ITextComponent button = withButton((isDistinctInputBusMode ?
+					new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct.yes") :
+					new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct.no")), "distinct");
+			withHoverTextTranslate(button, "gtadditions.multiblock.processing_array.distinct.info");
+			buttonText.appendSibling(button);
+			textList.add(buttonText);
+			textList.add(new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct2", isDistinctInputBusMode ?
+					new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct.yes") :
+					new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct.no")));
+		}
+		else {
+			textList.add(new TextComponentTranslation("gtadditions.multiblock.processing_array.distinct.no_bus"));
+		}
 		if(this.recipeMapWorkable.isActive()) {
 			textList.add(new TextComponentTranslation("gtadditions.multiblock.processing_array.locked"));
 		}

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -500,6 +500,7 @@ gtadditions.multiblock.processing_array.distinct2=[Click %s to Toggle]
 gtadditions.multiblock.processing_array.distinct.yes=§aYes
 gtadditions.multiblock.processing_array.distinct.no=§cNo
 gtadditions.multiblock.processing_array.distinct.info=If enabled, each bus will be treated as fully distinct from each other for recipe lookup. Useful for things like Extruder Shapes, Laser Lenses, etc..
+gtadditions.multiblock.processing_array.distinct.no_bus=There must be at least 1 item input for distinct mode to be enabled
 gtadditions.multiblock.processing_array.locked=§cMachine Hatch Locked
 
 # Assembly Line

--- a/src/main/resources/assets/gtadditions/lang/en_us.lang
+++ b/src/main/resources/assets/gtadditions/lang/en_us.lang
@@ -499,6 +499,7 @@ gtadditions.multiblock.processing_array.distinct=Distinct Buses:
 gtadditions.multiblock.processing_array.distinct2=[Click %s to Toggle]
 gtadditions.multiblock.processing_array.distinct.yes=§aYes
 gtadditions.multiblock.processing_array.distinct.no=§cNo
+gtadditions.multiblock.processing_array.distinct.disabled=§7N/A
 gtadditions.multiblock.processing_array.distinct.info=If enabled, each bus will be treated as fully distinct from each other for recipe lookup. Useful for things like Extruder Shapes, Laser Lenses, etc..
 gtadditions.multiblock.processing_array.distinct.no_bus=There must be at least 1 item input for distinct mode to be enabled
 gtadditions.multiblock.processing_array.locked=§cMachine Hatch Locked

--- a/src/main/resources/assets/gtadditions/lang/ru_ru.lang
+++ b/src/main/resources/assets/gtadditions/lang/ru_ru.lang
@@ -499,7 +499,9 @@ gtadditions.multiblock.processing_array.distinct=Distinct Buses:
 gtadditions.multiblock.processing_array.distinct2=[Click %s to Toggle]
 gtadditions.multiblock.processing_array.distinct.yes=§aYes
 gtadditions.multiblock.processing_array.distinct.no=§cNo
+gtadditions.multiblock.processing_array.distinct.disabled=§7N/A
 gtadditions.multiblock.processing_array.distinct.info=If enabled, each bus will be treated as fully distinct from each other for recipe lookup. Useful for things like Extruder Shapes, Laser Lenses, etc..
+gtadditions.multiblock.processing_array.distinct.no_bus=There must be at least 1 item input for distinct mode to be enabled
 gtadditions.multiblock.processing_array.locked=§cMachine Hatch Locked
 
 # Assembly Line

--- a/src/main/resources/assets/gtadditions/lang/zh_cn.lang
+++ b/src/main/resources/assets/gtadditions/lang/zh_cn.lang
@@ -499,7 +499,9 @@ gtadditions.multiblock.processing_array.distinct=Distinct Buses:
 gtadditions.multiblock.processing_array.distinct2=[Click %s to Toggle]
 gtadditions.multiblock.processing_array.distinct.yes=§aYes
 gtadditions.multiblock.processing_array.distinct.no=§cNo
+gtadditions.multiblock.processing_array.distinct.disabled=§7N/A
 gtadditions.multiblock.processing_array.distinct.info=If enabled, each bus will be treated as fully distinct from each other for recipe lookup. Useful for things like Extruder Shapes, Laser Lenses, etc..
+gtadditions.multiblock.processing_array.distinct.no_bus=There must be at least 1 item input for distinct mode to be enabled
 gtadditions.multiblock.processing_array.locked=§cMachine Hatch Locked
 
 # Assembly Line


### PR DESCRIPTION
Hides the button to enable distinct mode when there are no item input buses in the PA, to prevent a hang