### PR TITLE
MORE invalidations for PA

### DIFF
--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -402,6 +402,9 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 			this.machineTier = 0;
 			this.numberOfMachines = 0;
 			this.numberOfOperations = 0;
+			this.lastItemInputsMatrix = null;
+			this.lastItemInputs = null;
+			this.lastFluidInputs = null;
 		}
 
 		//Finds the Recipe Map of the passed Machine Stack and checks if it is a valid Recipe Map
@@ -475,6 +478,11 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 
 			//The Processing Array is limited to 1 Machine Interface per multiblock, and only has 1 slot
 			ItemStack currentMachine = controller.getAbilities(GACapabilities.PA_MACHINE_CONTAINER).get(0).getStackInSlot(0);
+
+			if (currentMachine.isEmpty()) {
+				invalidate();
+				return;
+			}
 
 			if (!ItemStack.areItemStacksEqual(this.machineItemStack, currentMachine)) {
 				RecipeMap<?> rmap = findRecipeMapAndCheckValid(currentMachine);

--- a/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
+++ b/src/main/java/gregicadditions/machines/TileEntityProcessingArray.java
@@ -654,8 +654,10 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 				multipliedRecipe = multiplyRecipe(importInventory.get(lastRecipeIndex), importFluids, currentRecipe, machineItemStack, recipeMap);
 				if(setupAndConsumeRecipeInputs(multipliedRecipe, lastRecipeIndex)) {
 					setupRecipe(multipliedRecipe);
-					return;
 				}
+				//if the recipe matches return true we HAVE enough of the input to proceed, but are not proceeding due to either lack of energy or output space.
+				//return earlier to avoid refreshing the input cache too early and missing the inventory change when this recipe is actually invalid.
+				return;
 			}
 
 			//If the previous recipe is null, check for a new recipe
@@ -676,9 +678,13 @@ public class TileEntityProcessingArray extends RecipeMapMultiblockController {
 					multipliedRecipe = multiplyRecipe(bus, importFluids, currentRecipe, machineItemStack, recipeMap);
 				}
 
-				if(multipliedRecipe != null && setupAndConsumeRecipeInputs(multipliedRecipe, i)) {
+				if(multipliedRecipe != null) {
+					if(setupAndConsumeRecipeInputs(multipliedRecipe, i)) {
+						setupRecipe(multipliedRecipe);
+					}
+					//if the recipe matches return true we HAVE enough of the input to proceed, but are not proceeding due to either lack of energy or output space.
+					//return earlier to avoid refreshing the input cache too early and missing the inventory change when this recipe is actually invalid.
 					lastRecipeIndex = i;
-					setupRecipe(multipliedRecipe);
 					break;
 				}
 			}


### PR DESCRIPTION
Invalidate even more cached variables when the multiblock deforms or the machine stacks are changed

return earlier when a cached valid recipe is found but cannot progress due to output bus being full or without power, as to not refresh all the cached item inputs too early.

waiting for enitiaty feedback on the Discord.
On my end this issue is fixed